### PR TITLE
fix(nav): disable bottom nav while a mobile modal dialog is open

### DIFF
--- a/src/OpenIPC.Viewer.App/Services/OverlayDialogPresenter.cs
+++ b/src/OpenIPC.Viewer.App/Services/OverlayDialogPresenter.cs
@@ -29,6 +29,18 @@ public static class OverlayDialogPresenter
 {
     private static readonly TimeSpan FadeIn = TimeSpan.FromMilliseconds(160);
 
+    // Number of overlay dialogs currently on screen. Mobile dialogs live in the
+    // TopLevel.OverlayLayer; the dim Border does not reliably intercept taps on
+    // the bottom nav, so the shell gates navigation on this instead. Desktop
+    // uses real modal Windows (ShowDialog) and never goes through here.
+    private static int _activeCount;
+
+    /// <summary>True while at least one overlay (mobile modal) dialog is open.</summary>
+    public static bool IsAnyOpen => _activeCount > 0;
+
+    /// <summary>Raised on the UI thread whenever <see cref="IsAnyOpen"/> may have changed.</summary>
+    public static event Action? ActiveChanged;
+
     public static async Task<TResult> ShowAsync<TResult>(Control content, Task<TResult> completion)
     {
         var overlay = GetOverlayLayer();
@@ -82,6 +94,8 @@ public static class OverlayDialogPresenter
         };
 
         overlay.Children.Add(dim);
+        _activeCount++;
+        ActiveChanged?.Invoke();
         // Kick the opacity transition after the first layout pass — set
         // synchronously the Avalonia renderer treats it as initial state
         // and skips the animation.
@@ -94,6 +108,8 @@ public static class OverlayDialogPresenter
         finally
         {
             overlay.Children.Remove(dim);
+            _activeCount--;
+            ActiveChanged?.Invoke();
         }
     }
 

--- a/src/OpenIPC.Viewer.App/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/MainWindowViewModel.cs
@@ -61,9 +61,19 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
 
         WeakReferenceMessenger.Default.Register<OpenCameraMessage>(this);
         WeakReferenceMessenger.Default.Register<GoBackToLibraryMessage>(this);
+
+        // While a mobile overlay dialog is open the bottom nav must not switch
+        // pages under it — the dim layer doesn't reliably swallow those taps.
+        // Re-evaluate CanNavigate whenever an overlay opens/closes; this greys
+        // out the nav buttons (Avalonia disables a control whose command can't
+        // execute). This VM is an app-lifetime singleton, so the static
+        // subscription lives as long as the process — no unsubscribe needed.
+        OverlayDialogPresenter.ActiveChanged += () => NavigateCommand.NotifyCanExecuteChanged();
     }
 
-    [RelayCommand]
+    private static bool CanNavigate() => !OverlayDialogPresenter.IsAnyOpen;
+
+    [RelayCommand(CanExecute = nameof(CanNavigate))]
     private void Navigate(string target)
     {
         if (_activeSingleCamera is not null && target != "library")


### PR DESCRIPTION
## Summary
Fixing Issue #5 
- overlay dialogs live in OverlayLayer; the dim layer doesn't swallow nav taps, so navigation switched CurrentPage under the open dialog
- OverlayDialogPresenter now tracks open overlays (IsAnyOpen + ActiveChanged)
- gate NavigateCommand on CanNavigate; nav buttons grey out until the dialog closes
- desktop is unaffected (real modal ShowDialog windows)

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
