### PR TITLE
fix(i18n): refresh all localized bindings live on language switch

### DIFF
--- a/src/OpenIPC.Viewer.App/Services/Localizer.cs
+++ b/src/OpenIPC.Viewer.App/Services/Localizer.cs
@@ -6,8 +6,12 @@ namespace OpenIPC.Viewer.App.Services;
 
 // Tiny ICU-free localizer. Static singleton because XAML's {Binding [Key],
 // Source={x:Static svc:Localizer.Instance}} pattern needs a static reference.
-// PropertyChanged on "Item[]" tells all indexed bindings to re-evaluate when
-// SetLanguage flips the active dict — no relaunch needed.
+// SetLanguage raises PropertyChanged with an empty name ("everything changed")
+// so every binding on Localizer.Instance re-reads when the active dict flips —
+// no relaunch needed. Note: the WPF "Item[]" indexer convention does NOT work
+// here — Avalonia's accessor only re-reads when PropertyName equals the CLR
+// indexer name ("Item") or is null/empty, so persistent controls like the
+// bottom nav stayed stale on "Item[]". Empty name is the reliable signal.
 //
 // EN/RU only for now; adding a third language = one more dict + one more
 // LangCode value. Missing keys fall back to the key itself, so adding a new
@@ -41,7 +45,9 @@ public sealed class Localizer : INotifyPropertyChanged
             _ => English,
         };
         _active = resolved;
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("Item[]"));
+        // Empty/null name = "all properties changed"; Avalonia's INPC accessor
+        // re-reads on string.IsNullOrEmpty(PropertyName). "Item[]" would not match.
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(string.Empty));
     }
 
     private static LangCode DetectSystem()


### PR DESCRIPTION
- SetLanguage raised PropertyChanged("Item[]"), a WPF-ism Avalonia ignores
- Avalonia's INPC accessor re-reads only on PropertyName=="Item" or empty; string-keyed indexer bindings use the CLR name "Item", not "Item[]"
- bottom nav / sidebar (persistent controls) stayed stale until restart; pages only looked translated because they rebuild on navigation
- raise PropertyChanged(string.Empty) — "all changed" — so every binding on Localizer.Instance re-reads instantly

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary
Fixing issue #8 
- SetLanguage raised PropertyChanged("Item[]"), a WPF-ism Avalonia ignores
- Avalonia's INPC accessor re-reads only on PropertyName=="Item" or empty; string-keyed indexer bindings use the CLR name "Item", not "Item[]"
- bottom nav / sidebar (persistent controls) stayed stale until restart; pages only looked translated because they rebuild on navigation
- raise PropertyChanged(string.Empty) — "all changed" — so every binding on Localizer.Instance re-reads instantly


## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes
<img width="386" height="839" alt="image" src="https://github.com/user-attachments/assets/547ab3e3-3abe-47cc-9181-85f9f5be856b" />
<img width="383" height="833" alt="image" src="https://github.com/user-attachments/assets/cc3389ac-51fe-4588-b552-26115a786cf9" />

<!-- For UI changes, before/after screenshots help. -->
