### PR TITLE
fix(camera-editor): keep Save button on-screen regardless of test status

### DIFF
--- a/src/OpenIPC.Viewer.App/Views/Dialogs/CameraEditorContent.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/CameraEditorContent.axaml
@@ -100,21 +100,25 @@
     </ScrollViewer>
 
     <Grid Grid.Row="2" ColumnDefinitions="Auto,*,Auto,Auto" Margin="0,24,0,0">
-      <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
-        <Button Content="{Binding [CameraEditor.Button.TestConnection], Source={x:Static svc:Localizer.Instance}}"
-                Command="{Binding TestConnectionCommand}"
-                Padding="12,8"
-                Background="Transparent"
-                BorderBrush="{StaticResource BorderMediumBrush}"
-                BorderThickness="1"
-                CornerRadius="6"
-                Foreground="{StaticResource TextPrimaryBrush}" />
-        <TextBlock Text="{Binding TestStatus}"
-                   FontSize="{StaticResource FontSizeSm}"
-                   Foreground="{StaticResource TextSecondaryBrush}"
-                   VerticalAlignment="Center"
-                   IsVisible="{Binding TestStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-      </StackPanel>
+      <Button Grid.Column="0"
+              Content="{Binding [CameraEditor.Button.TestConnection], Source={x:Static svc:Localizer.Instance}}"
+              Command="{Binding TestConnectionCommand}"
+              Padding="12,8"
+              VerticalAlignment="Center"
+              Background="Transparent"
+              BorderBrush="{StaticResource BorderMediumBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Foreground="{StaticResource TextPrimaryBrush}" />
+      <TextBlock Grid.Column="1"
+                 Text="{Binding TestStatus}"
+                 FontSize="{StaticResource FontSizeSm}"
+                 Foreground="{StaticResource TextSecondaryBrush}"
+                 VerticalAlignment="Center"
+                 Margin="10,0"
+                 TextTrimming="CharacterEllipsis"
+                 ToolTip.Tip="{Binding TestStatus}"
+                 IsVisible="{Binding TestStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
       <Button Grid.Column="2"
               Name="CancelButton"
               Content="{Binding [Common.Cancel], Source={x:Static svc:Localizer.Instance}}"


### PR DESCRIPTION
- test status/error lived in the Auto column next to the button and widened the row
- move TestStatus into the flexible * column with CharacterEllipsis, full text in ToolTip
- Cancel/Save are now always pinned to the right edge

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary
Fixing Issue #4 
- test status/error lived in the Auto column next to the button and widened the row
- move TestStatus into the flexible * column with CharacterEllipsis, full text in ToolTip
- Cancel/Save are now always pinned to the right edge

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes
<img width="337" height="613" alt="image" src="https://github.com/user-attachments/assets/4dd23e0a-f3f5-496a-b61f-8b3da1959153" />

<!-- For UI changes, before/after screenshots help. -->
