### PR TITLE
fix(onvif): make WS-Discovery work on Android/iOS

### DIFF
--- a/src/OpenIPC.Viewer.Devices/Onvif/Discovery/PlatformSafeUdpClient.cs
+++ b/src/OpenIPC.Viewer.Devices/Onvif/Discovery/PlatformSafeUdpClient.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Onvif.Core.Discovery.Interfaces;
+
+namespace OpenIPC.Viewer.Devices.Onvif.Discovery;
+
+// Drop-in IUdpClient for Onvif.Core's WSDiscovery. The stock UdpClientWrapper
+// calls IPGlobalProperties.GetActiveTcpListeners() in its constructor (a
+// port-collision pre-check) — that API is unimplemented on Android/iOS and
+// throws PlatformNotSupportedException ("Arg_PlatformNotSupported"), so device
+// discovery died before sending a single probe on mobile.
+//
+// This implementation skips that check: it binds an ephemeral UDP socket and
+// sends the multicast probe to 239.255.255.250:3702. WS-Discovery ProbeMatch
+// replies come back as *unicast* to our source port, so we never join a
+// multicast group — which also means no Android WifiManager.MulticastLock is
+// required. Works identically on desktop, so no per-platform branching.
+internal sealed class PlatformSafeUdpClient : IUdpClient
+{
+    private readonly UdpClient _client;
+
+    public PlatformSafeUdpClient()
+    {
+        // Port 0 = let the OS pick a free ephemeral port. The stock wrapper
+        // hard-bound port 80, which is both privileged and collision-prone.
+        _client = new UdpClient(new IPEndPoint(IPAddress.Any, 0)) { EnableBroadcast = true };
+    }
+
+    public short Ttl
+    {
+        get => _client.Ttl;
+        set => _client.Ttl = value;
+    }
+
+    public Task<int> SendAsync(byte[] datagram, int bytes, IPEndPoint endPoint) =>
+        _client.SendAsync(datagram, bytes, endPoint);
+
+    public Task<UdpReceiveResult> ReceiveAsync() => _client.ReceiveAsync();
+
+    public void Close() => _client.Close();
+
+    public void Dispose() => _client.Dispose();
+}

--- a/src/OpenIPC.Viewer.Devices/Onvif/Discovery/WsDiscoveryService.cs
+++ b/src/OpenIPC.Viewer.Devices/Onvif/Discovery/WsDiscoveryService.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Onvif.Core.Discovery;
-using Onvif.Core.Discovery.Common;
 using Onvif.Core.Discovery.Models;
 using OpenIPC.Viewer.Core.Onvif.Discovery;
 
@@ -32,7 +31,9 @@ public sealed class WsDiscoveryService : IDiscoveryService
     {
         var seconds = Math.Max(1, (int)Math.Ceiling(timeout.TotalSeconds));
         var ws = new WSDiscovery();
-        var client = new UdpClientWrapper();
+        // Our own IUdpClient — the stock UdpClientWrapper crashes on Android/iOS
+        // (GetActiveTcpListeners is PlatformNotSupported). See PlatformSafeUdpClient.
+        var client = new PlatformSafeUdpClient();
 
         _logger.LogDebug("WS-Discovery scan starting (timeout={Seconds}s)", seconds);
         IEnumerable<DiscoveryDevice> devices;


### PR DESCRIPTION
Onvif.Core's UdpClientWrapper calls IPGlobalProperties.GetActiveTcpListeners() in its ctor — unimplemented on mobile, so discovery threw Arg_PlatformNotSupported before sending a probe.

- add PlatformSafeUdpClient (IUdpClient) that skips that pre-check, binds an ephemeral UDP socket and sends the multicast probe; replies are unicast so no multicast-group join / Android MulticastLock is needed
- WsDiscoveryService uses it instead of UdpClientWrapper

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

Onvif.Core's UdpClientWrapper calls IPGlobalProperties.GetActiveTcpListeners() in its ctor — unimplemented on mobile, so discovery threw Arg_PlatformNotSupported before sending a probe.

- add PlatformSafeUdpClient (IUdpClient) that skips that pre-check, binds an ephemeral UDP socket and sends the multicast probe; replies are unicast so no multicast-group join / Android MulticastLock is needed
- WsDiscoveryService uses it instead of UdpClientWrapper

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [ ] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
