### PR TITLE
feat: archive pro (player, timeline, calendar, clip export)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ and scope live in the planning docs (`dashboard-ideas-roadmap-ru.md`).
 | 13 | SSH device suite | SSH terminal, SCP file manager, open-in-browser, config push | ✅ Done |
 | 14 | Snapshots & viewer | Always-HD snapshot, snapshot browser, built-in viewer + basic editor | ✅ Done |
 | 15 | Local AI analytics | ONNX object detection per camera, auto-record, control center, CPU fallback | ✅ Done |
-| 16 | Archive pro | Fragmented MP4, activity calendar, timeline zoom, clip export | 📋 Planned |
+| 16 | Archive pro | Fragmented MP4, activity calendar, timeline zoom, clip export | ✅ Done |
 | 17 | Community & app-level | Tabbed layouts, config export/import, notifications, white-label, issue reporter, RBAC | 📋 Planned |
 | 18 | Streq remote access | Cloud multistreaming across devices: LAN/overlay/relay routing, enrollment, WebRTC/HLS, cross-device sync | 📋 Planned |
 

--- a/src/OpenIPC.Viewer.Android/Composition.cs
+++ b/src/OpenIPC.Viewer.Android/Composition.cs
@@ -48,6 +48,10 @@ internal static class Composition
         services.AddSingleton<IRecorder>(sp =>
             new AndroidRecorder(context, sp.GetRequiredService<ILoggerFactory>()));
 
+        // Clip export (Phase 16.5) — in-process libavformat (no subprocess on Android).
+        services.AddSingleton<OpenIPC.Viewer.Core.Archive.IClipExporter,
+            OpenIPC.Viewer.Video.Recording.LibavformatClipExporter>();
+
         services.AddSharedServices();
 
         var provider = services.BuildServiceProvider(validateScopes: true);

--- a/src/OpenIPC.Viewer.App/App.axaml
+++ b/src/OpenIPC.Viewer.App/App.axaml
@@ -26,6 +26,9 @@
     <DataTemplate DataType="vm:RecordingsPageViewModel">
       <pages:RecordingsPage />
     </DataTemplate>
+    <DataTemplate DataType="vm:RecordingPlayerPageViewModel">
+      <pages:RecordingPlayerPage />
+    </DataTemplate>
     <DataTemplate DataType="vm:EventsPageViewModel">
       <pages:EventsPage />
     </DataTemplate>

--- a/src/OpenIPC.Viewer.App/Controls/TimelineControl.cs
+++ b/src/OpenIPC.Viewer.App/Controls/TimelineControl.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using OpenIPC.Viewer.Core.Timeline;
+
+namespace OpenIPC.Viewer.App.Controls;
+
+// Canvas-rendered archive timeline (Phase 16.4). Draws recording segments,
+// motion/detection markers and the playhead on one scale; supports
+// cursor-anchored wheel zoom, drag-pan, click-to-seek and marker tooltips.
+// Rendered with DrawingContext (not hundreds of visuals) — markers are bucketed
+// per pixel column so a day of detections stays cheap to paint.
+public sealed class TimelineControl : Control
+{
+    public static readonly StyledProperty<DateTime> TotalStartProperty =
+        AvaloniaProperty.Register<TimelineControl, DateTime>(nameof(TotalStart));
+
+    public static readonly StyledProperty<DateTime> TotalEndProperty =
+        AvaloniaProperty.Register<TimelineControl, DateTime>(nameof(TotalEnd));
+
+    public static readonly StyledProperty<IReadOnlyList<TimelineSegment>?> SegmentsProperty =
+        AvaloniaProperty.Register<TimelineControl, IReadOnlyList<TimelineSegment>?>(nameof(Segments));
+
+    public static readonly StyledProperty<IReadOnlyList<TimelineMarker>?> MarkersProperty =
+        AvaloniaProperty.Register<TimelineControl, IReadOnlyList<TimelineMarker>?>(nameof(Markers));
+
+    // Playhead position as an absolute time; null hides it.
+    public static readonly StyledProperty<DateTime?> PositionProperty =
+        AvaloniaProperty.Register<TimelineControl, DateTime?>(nameof(Position));
+
+    // Executed with a DateTime parameter when the user clicks/seeks.
+    public static readonly StyledProperty<ICommand?> SeekCommandProperty =
+        AvaloniaProperty.Register<TimelineControl, ICommand?>(nameof(SeekCommand));
+
+    public static readonly StyledProperty<IBrush?> TrackBrushProperty =
+        AvaloniaProperty.Register<TimelineControl, IBrush?>(nameof(TrackBrush), new SolidColorBrush(Color.FromRgb(0x1B, 0x20, 0x27)));
+
+    public static readonly StyledProperty<IBrush?> SegmentBrushProperty =
+        AvaloniaProperty.Register<TimelineControl, IBrush?>(nameof(SegmentBrush), new SolidColorBrush(Color.FromRgb(0x2E, 0x3A, 0x46)));
+
+    public static readonly StyledProperty<IBrush?> PlayheadBrushProperty =
+        AvaloniaProperty.Register<TimelineControl, IBrush?>(nameof(PlayheadBrush), new SolidColorBrush(Color.FromRgb(0x21, 0x96, 0xF3)));
+
+    public static readonly StyledProperty<IBrush?> LabelBrushProperty =
+        AvaloniaProperty.Register<TimelineControl, IBrush?>(nameof(LabelBrush), new SolidColorBrush(Color.FromRgb(0x8A, 0x97, 0xA6)));
+
+    private static readonly IBrush MotionBrush = new SolidColorBrush(Color.FromRgb(0xFF, 0x98, 0x00));
+    private static readonly IBrush DetectionBrush = new SolidColorBrush(Color.FromRgb(0xE0, 0x40, 0x40));
+    private static readonly IBrush OtherBrush = new SolidColorBrush(Color.FromRgb(0x8A, 0x97, 0xA6));
+
+    private const double TrackTop = 8;
+    private const double TrackHeight = 26;
+    private const double MarkerHitPx = 6;
+    private const double PanThresholdPx = 4;
+
+    private TimelineViewport? _viewport;
+    private Point? _pressPoint;
+    private bool _dragging;
+
+    static TimelineControl()
+    {
+        AffectsRender<TimelineControl>(
+            TotalStartProperty, TotalEndProperty, SegmentsProperty,
+            MarkersProperty, PositionProperty, TrackBrushProperty,
+            SegmentBrushProperty, PlayheadBrushProperty, LabelBrushProperty);
+    }
+
+    public DateTime TotalStart { get => GetValue(TotalStartProperty); set => SetValue(TotalStartProperty, value); }
+    public DateTime TotalEnd { get => GetValue(TotalEndProperty); set => SetValue(TotalEndProperty, value); }
+    public IReadOnlyList<TimelineSegment>? Segments { get => GetValue(SegmentsProperty); set => SetValue(SegmentsProperty, value); }
+    public IReadOnlyList<TimelineMarker>? Markers { get => GetValue(MarkersProperty); set => SetValue(MarkersProperty, value); }
+    public DateTime? Position { get => GetValue(PositionProperty); set => SetValue(PositionProperty, value); }
+    public ICommand? SeekCommand { get => GetValue(SeekCommandProperty); set => SetValue(SeekCommandProperty, value); }
+    public IBrush? TrackBrush { get => GetValue(TrackBrushProperty); set => SetValue(TrackBrushProperty, value); }
+    public IBrush? SegmentBrush { get => GetValue(SegmentBrushProperty); set => SetValue(SegmentBrushProperty, value); }
+    public IBrush? PlayheadBrush { get => GetValue(PlayheadBrushProperty); set => SetValue(PlayheadBrushProperty, value); }
+    public IBrush? LabelBrush { get => GetValue(LabelBrushProperty); set => SetValue(LabelBrushProperty, value); }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        // Rebuild the viewport when the total range changes (new recording).
+        if (change.Property == TotalStartProperty || change.Property == TotalEndProperty)
+            _viewport = null;
+    }
+
+    private TimelineViewport Viewport =>
+        _viewport ??= new TimelineViewport(TotalStart, TotalEnd);
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        var w = Bounds.Width;
+        var h = Bounds.Height;
+        if (w <= 0 || h <= 0 || TotalEnd <= TotalStart) return;
+
+        var vp = Viewport;
+
+        // Track background.
+        context.DrawRectangle(TrackBrush, null, new Rect(0, TrackTop, w, TrackHeight));
+
+        // Recording segments.
+        var segs = Segments;
+        if (segs is not null)
+        {
+            foreach (var s in segs)
+            {
+                var x0 = Math.Max(0, vp.TimeToX(s.Start, w));
+                var x1 = Math.Min(w, vp.TimeToX(s.End, w));
+                if (x1 <= x0) continue;
+                context.DrawRectangle(SegmentBrush, null, new Rect(x0, TrackTop, x1 - x0, TrackHeight));
+            }
+        }
+
+        DrawMarkers(context, vp, w);
+        DrawTicks(context, vp, w, h);
+        DrawPlayhead(context, vp, w);
+    }
+
+    private void DrawMarkers(DrawingContext context, TimelineViewport vp, double w)
+    {
+        var markers = Markers;
+        if (markers is null || markers.Count == 0) return;
+
+        // Bucket by integer pixel column so a dense day collapses to one tick
+        // per column (cheap paint + readable). The bucket's kind is the most
+        // "severe" present (Detection > Motion > Other).
+        var buckets = new Dictionary<int, TimelineMarkerKind>();
+        foreach (var m in markers)
+        {
+            if (m.Time < vp.VisibleStart || m.Time > vp.VisibleEnd) continue;
+            var col = (int)Math.Round(vp.TimeToX(m.Time, w));
+            if (col < 0 || col > w) continue;
+            if (buckets.TryGetValue(col, out var existing))
+                buckets[col] = Severer(existing, m.Kind);
+            else
+                buckets[col] = m.Kind;
+        }
+
+        foreach (var (col, kind) in buckets)
+        {
+            var brush = BrushFor(kind);
+            context.DrawRectangle(brush, null, new Rect(col - 1, TrackTop, 2, TrackHeight));
+        }
+    }
+
+    private void DrawTicks(DrawingContext context, TimelineViewport vp, double w, double h)
+    {
+        var step = TimelineTicks.ChooseStep(vp.VisibleSeconds, w);
+        var stepSec = step.TotalSeconds;
+        if (stepSec <= 0) return;
+
+        // First aligned tick at or after VisibleStart (aligned to local time).
+        var startLocal = vp.VisibleStart.ToLocalTime();
+        var epoch = new DateTime(startLocal.Year, startLocal.Month, startLocal.Day, 0, 0, 0, DateTimeKind.Local);
+        var sinceMidnight = (startLocal - epoch).TotalSeconds;
+        var firstOffset = Math.Ceiling(sinceMidnight / stepSec) * stepSec;
+        var tick = epoch.AddSeconds(firstOffset);
+
+        var pen = new Pen(LabelBrush, 1);
+        var labelY = h - 14;
+        while (tick.ToUniversalTime() <= vp.VisibleEnd)
+        {
+            var x = vp.TimeToX(tick.ToUniversalTime(), w);
+            context.DrawLine(pen, new Point(x, TrackTop + TrackHeight), new Point(x, TrackTop + TrackHeight + 4));
+            var text = new FormattedText(FormatTick(tick, stepSec), CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight, Typeface.Default, 10, LabelBrush);
+            context.DrawText(text, new Point(x + 3, labelY));
+            tick = tick.AddSeconds(stepSec);
+        }
+    }
+
+    private void DrawPlayhead(DrawingContext context, TimelineViewport vp, double w)
+    {
+        if (Position is not { } pos) return;
+        if (pos < vp.VisibleStart || pos > vp.VisibleEnd) return;
+        var x = vp.TimeToX(pos, w);
+        var pen = new Pen(PlayheadBrush, 2);
+        context.DrawLine(pen, new Point(x, 0), new Point(x, TrackTop + TrackHeight + 4));
+        // Small head triangle.
+        var geo = new StreamGeometry();
+        using (var g = geo.Open())
+        {
+            g.BeginFigure(new Point(x - 4, 0), true);
+            g.LineTo(new Point(x + 4, 0));
+            g.LineTo(new Point(x, 6));
+            g.EndFigure(true);
+        }
+        context.DrawGeometry(PlayheadBrush, null, geo);
+    }
+
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        base.OnPointerWheelChanged(e);
+        var w = Bounds.Width;
+        if (w <= 0) return;
+        var anchorX = e.GetPosition(this).X;
+        var factor = Math.Pow(1.2, e.Delta.Y != 0 ? e.Delta.Y : e.Delta.X);
+        Viewport.ZoomAt(anchorX, w, factor);
+        InvalidateVisual();
+        e.Handled = true;
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        _pressPoint = e.GetPosition(this);
+        _dragging = false;
+        e.Pointer.Capture(this);
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        base.OnPointerMoved(e);
+        var p = e.GetPosition(this);
+        var w = Bounds.Width;
+
+        if (_pressPoint is { } start && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            var dx = p.X - start.X;
+            if (_dragging || Math.Abs(dx) > PanThresholdPx)
+            {
+                _dragging = true;
+                Viewport.Pan(p.X - start.X, w);
+                _pressPoint = p; // incremental pan
+                InvalidateVisual();
+            }
+            return;
+        }
+
+        // Hover tooltip: nearest marker within a few pixels.
+        var hit = HitTestMarker(p.X, w);
+        ToolTip.SetTip(this, hit?.Label);
+        ToolTip.SetIsOpen(this, hit is not null);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        base.OnPointerReleased(e);
+        var p = e.GetPosition(this);
+        var w = Bounds.Width;
+        e.Pointer.Capture(null);
+
+        if (!_dragging && _pressPoint is not null)
+        {
+            // Click: seek to the marker under the cursor, else to the raw time.
+            var hit = HitTestMarker(p.X, w);
+            var target = hit?.Time ?? Viewport.XToTime(p.X, w);
+            if (SeekCommand?.CanExecute(target) == true)
+                SeekCommand.Execute(target);
+        }
+
+        _pressPoint = null;
+        _dragging = false;
+    }
+
+    private TimelineMarker? HitTestMarker(double x, double w)
+    {
+        var markers = Markers;
+        if (markers is null || markers.Count == 0) return null;
+        var vp = Viewport;
+        TimelineMarker? best = null;
+        var bestDist = MarkerHitPx;
+        foreach (var m in markers)
+        {
+            if (m.Time < vp.VisibleStart || m.Time > vp.VisibleEnd) continue;
+            var mx = vp.TimeToX(m.Time, w);
+            var d = Math.Abs(mx - x);
+            if (d <= bestDist)
+            {
+                bestDist = d;
+                best = m;
+            }
+        }
+        return best;
+    }
+
+    // Detection is the most prominent, then Motion, then Other.
+    private static int Rank(TimelineMarkerKind k) => k switch
+    {
+        TimelineMarkerKind.Detection => 2,
+        TimelineMarkerKind.Motion => 1,
+        _ => 0,
+    };
+
+    private static TimelineMarkerKind Severer(TimelineMarkerKind a, TimelineMarkerKind b) =>
+        Rank(a) >= Rank(b) ? a : b;
+
+    private static IBrush BrushFor(TimelineMarkerKind kind) => kind switch
+    {
+        TimelineMarkerKind.Detection => DetectionBrush,
+        TimelineMarkerKind.Motion => MotionBrush,
+        _ => OtherBrush,
+    };
+
+    private static string FormatTick(DateTime localTick, double stepSec) =>
+        stepSec >= 3600
+            ? localTick.ToString("HH:mm", CultureInfo.CurrentCulture)
+            : stepSec >= 60
+                ? localTick.ToString("HH:mm", CultureInfo.CurrentCulture)
+                : localTick.ToString("HH:mm:ss", CultureInfo.CurrentCulture);
+}

--- a/src/OpenIPC.Viewer.App/Controls/TimelineControl.cs
+++ b/src/OpenIPC.Viewer.App/Controls/TimelineControl.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Media;
 using OpenIPC.Viewer.Core.Timeline;
@@ -37,6 +38,17 @@ public sealed class TimelineControl : Control
     public static readonly StyledProperty<ICommand?> SeekCommandProperty =
         AvaloniaProperty.Register<TimelineControl, ICommand?>(nameof(SeekCommand));
 
+    // In/out selection (16.5), absolute times. Two-way so dragging the handles
+    // pushes back to the VM.
+    public static readonly StyledProperty<DateTime?> SelectionStartProperty =
+        AvaloniaProperty.Register<TimelineControl, DateTime?>(nameof(SelectionStart), defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<DateTime?> SelectionEndProperty =
+        AvaloniaProperty.Register<TimelineControl, DateTime?>(nameof(SelectionEnd), defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<IBrush?> SelectionBrushProperty =
+        AvaloniaProperty.Register<TimelineControl, IBrush?>(nameof(SelectionBrush), new SolidColorBrush(Color.FromArgb(0x40, 0x21, 0x96, 0xF3)));
+
     public static readonly StyledProperty<IBrush?> TrackBrushProperty =
         AvaloniaProperty.Register<TimelineControl, IBrush?>(nameof(TrackBrush), new SolidColorBrush(Color.FromRgb(0x1B, 0x20, 0x27)));
 
@@ -57,17 +69,22 @@ public sealed class TimelineControl : Control
     private const double TrackHeight = 26;
     private const double MarkerHitPx = 6;
     private const double PanThresholdPx = 4;
+    private const double HandleHitPx = 8;
+
+    private enum HandleDrag { None, Start, End }
 
     private TimelineViewport? _viewport;
     private Point? _pressPoint;
     private bool _dragging;
+    private HandleDrag _handleDrag;
 
     static TimelineControl()
     {
         AffectsRender<TimelineControl>(
             TotalStartProperty, TotalEndProperty, SegmentsProperty,
             MarkersProperty, PositionProperty, TrackBrushProperty,
-            SegmentBrushProperty, PlayheadBrushProperty, LabelBrushProperty);
+            SegmentBrushProperty, PlayheadBrushProperty, LabelBrushProperty,
+            SelectionStartProperty, SelectionEndProperty, SelectionBrushProperty);
     }
 
     public DateTime TotalStart { get => GetValue(TotalStartProperty); set => SetValue(TotalStartProperty, value); }
@@ -76,6 +93,9 @@ public sealed class TimelineControl : Control
     public IReadOnlyList<TimelineMarker>? Markers { get => GetValue(MarkersProperty); set => SetValue(MarkersProperty, value); }
     public DateTime? Position { get => GetValue(PositionProperty); set => SetValue(PositionProperty, value); }
     public ICommand? SeekCommand { get => GetValue(SeekCommandProperty); set => SetValue(SeekCommandProperty, value); }
+    public DateTime? SelectionStart { get => GetValue(SelectionStartProperty); set => SetValue(SelectionStartProperty, value); }
+    public DateTime? SelectionEnd { get => GetValue(SelectionEndProperty); set => SetValue(SelectionEndProperty, value); }
+    public IBrush? SelectionBrush { get => GetValue(SelectionBrushProperty); set => SetValue(SelectionBrushProperty, value); }
     public IBrush? TrackBrush { get => GetValue(TrackBrushProperty); set => SetValue(TrackBrushProperty, value); }
     public IBrush? SegmentBrush { get => GetValue(SegmentBrushProperty); set => SetValue(SegmentBrushProperty, value); }
     public IBrush? PlayheadBrush { get => GetValue(PlayheadBrushProperty); set => SetValue(PlayheadBrushProperty, value); }
@@ -117,9 +137,25 @@ public sealed class TimelineControl : Control
             }
         }
 
+        DrawSelection(context, vp, w);
         DrawMarkers(context, vp, w);
         DrawTicks(context, vp, w, h);
         DrawPlayhead(context, vp, w);
+    }
+
+    private void DrawSelection(DrawingContext context, TimelineViewport vp, double w)
+    {
+        if (SelectionStart is not { } a || SelectionEnd is not { } b) return;
+        var s = a <= b ? a : b;
+        var e = a <= b ? b : a;
+        var xs = Math.Clamp(vp.TimeToX(s, w), 0, w);
+        var xe = Math.Clamp(vp.TimeToX(e, w), 0, w);
+        if (xe < xs) (xs, xe) = (xe, xs);
+
+        context.DrawRectangle(SelectionBrush, null, new Rect(xs, TrackTop, Math.Max(0, xe - xs), TrackHeight));
+        var handle = new Pen(PlayheadBrush, 3);
+        context.DrawLine(handle, new Point(xs, TrackTop - 2), new Point(xs, TrackTop + TrackHeight + 2));
+        context.DrawLine(handle, new Point(xe, TrackTop - 2), new Point(xe, TrackTop + TrackHeight + 2));
     }
 
     private void DrawMarkers(DrawingContext context, TimelineViewport vp, double w)
@@ -209,7 +245,19 @@ public sealed class TimelineControl : Control
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
         base.OnPointerPressed(e);
-        _pressPoint = e.GetPosition(this);
+        var p = e.GetPosition(this);
+        var w = Bounds.Width;
+
+        // Grab an in/out handle if the press lands near one.
+        _handleDrag = HitTestHandle(p.X, w);
+        if (_handleDrag != HandleDrag.None)
+        {
+            e.Pointer.Capture(this);
+            e.Handled = true;
+            return;
+        }
+
+        _pressPoint = p;
         _dragging = false;
         e.Pointer.Capture(this);
     }
@@ -219,6 +267,17 @@ public sealed class TimelineControl : Control
         base.OnPointerMoved(e);
         var p = e.GetPosition(this);
         var w = Bounds.Width;
+
+        if (_handleDrag != HandleDrag.None && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
+        {
+            var t = Viewport.XToTime(Math.Clamp(p.X, 0, w), w);
+            if (_handleDrag == HandleDrag.Start)
+                SetCurrentValue(SelectionStartProperty, t);
+            else
+                SetCurrentValue(SelectionEndProperty, t);
+            InvalidateVisual();
+            return;
+        }
 
         if (_pressPoint is { } start && e.GetCurrentPoint(this).Properties.IsLeftButtonPressed)
         {
@@ -246,6 +305,13 @@ public sealed class TimelineControl : Control
         var w = Bounds.Width;
         e.Pointer.Capture(null);
 
+        if (_handleDrag != HandleDrag.None)
+        {
+            _handleDrag = HandleDrag.None;
+            _pressPoint = null;
+            return;
+        }
+
         if (!_dragging && _pressPoint is not null)
         {
             // Click: seek to the marker under the cursor, else to the raw time.
@@ -257,6 +323,19 @@ public sealed class TimelineControl : Control
 
         _pressPoint = null;
         _dragging = false;
+    }
+
+    private HandleDrag HitTestHandle(double x, double w)
+    {
+        if (SelectionStart is not { } a || SelectionEnd is not { } b) return HandleDrag.None;
+        var vp = Viewport;
+        // Each handle maps to its own property; if dragging inverts the order the
+        // VM normalizes min/max at export time.
+        var ds = Math.Abs(x - vp.TimeToX(a, w));
+        var de = Math.Abs(x - vp.TimeToX(b, w));
+        if (ds <= HandleHitPx && ds <= de) return HandleDrag.Start;
+        if (de <= HandleHitPx) return HandleDrag.End;
+        return HandleDrag.None;
     }
 
     private TimelineMarker? HitTestMarker(double x, double w)

--- a/src/OpenIPC.Viewer.App/Controls/TimelineControl.cs
+++ b/src/OpenIPC.Viewer.App/Controls/TimelineControl.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
 using Avalonia.Input;
+using Avalonia.Input.GestureRecognizers;
 using Avalonia.Media;
 using OpenIPC.Viewer.Core.Timeline;
 
@@ -74,6 +75,16 @@ public sealed class TimelineControl : Control
     private enum HandleDrag { None, Start, End }
 
     private TimelineViewport? _viewport;
+    private double _lastPinchScale = 1.0;
+
+    public TimelineControl()
+    {
+        // Pinch-to-zoom for touch (Phase 16.4) — the wheel has no touch
+        // equivalent, so Android/iOS would otherwise be unable to zoom.
+        GestureRecognizers.Add(new PinchGestureRecognizer());
+        Pinch += OnPinch;
+        PinchEnded += OnPinchEnded;
+    }
     private Point? _pressPoint;
     private bool _dragging;
     private HandleDrag _handleDrag;
@@ -239,6 +250,29 @@ public sealed class TimelineControl : Control
         var factor = Math.Pow(1.2, e.Delta.Y != 0 ? e.Delta.Y : e.Delta.X);
         Viewport.ZoomAt(anchorX, w, factor);
         InvalidateVisual();
+        e.Handled = true;
+    }
+
+    // Pinch zoom (touch). Scale is cumulative from gesture start (~1.0), so we
+    // apply the per-event delta and anchor on the pinch midpoint — same
+    // cursor-anchored zoom as the wheel.
+    private void OnPinch(object? sender, PinchEventArgs e)
+    {
+        var w = Bounds.Width;
+        if (w <= 0) return;
+        var factor = _lastPinchScale > 0 ? e.Scale / _lastPinchScale : 1.0;
+        _lastPinchScale = e.Scale;
+        if (factor > 0 && Math.Abs(factor - 1.0) > 0.0001)
+        {
+            Viewport.ZoomAt(e.ScaleOrigin.X * w, w, factor);
+            InvalidateVisual();
+        }
+        e.Handled = true;
+    }
+
+    private void OnPinchEnded(object? sender, PinchEndedEventArgs e)
+    {
+        _lastPinchScale = 1.0;
         e.Handled = true;
     }
 

--- a/src/OpenIPC.Viewer.App/Messages/OpenCameraMessage.cs
+++ b/src/OpenIPC.Viewer.App/Messages/OpenCameraMessage.cs
@@ -1,10 +1,18 @@
 using OpenIPC.Viewer.Core.Entities;
+using OpenIPC.Viewer.Core.Recording;
 
 namespace OpenIPC.Viewer.App.Messages;
 
 public sealed record OpenCameraMessage(CameraId CameraId);
 
 public sealed record GoBackToLibraryMessage;
+
+// Phase 16: open the recordings player on a recorded segment, and return to
+// the recordings list. CameraName travels with the message so the player can
+// label itself without another directory lookup.
+public sealed record OpenRecordingMessage(Recording Recording, string CameraName);
+
+public sealed record GoBackToRecordingsMessage;
 
 public sealed record WindowMinimizedMessage;
 

--- a/src/OpenIPC.Viewer.App/Services/Localizer.cs
+++ b/src/OpenIPC.Viewer.App/Services/Localizer.cs
@@ -96,6 +96,7 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Common.Loading"] = "Loading…",
         ["Common.Retry"] = "Retry",
         ["Common.Close"] = "Close",
+        ["Common.All"] = "All days",
 
         ["Stream.Connecting"] = "Connecting…",
         ["Stream.Reconnecting"] = "Reconnecting…",
@@ -416,6 +417,7 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Common.Loading"] = "Загрузка…",
         ["Common.Retry"] = "Повторить",
         ["Common.Close"] = "Закрыть",
+        ["Common.All"] = "Все дни",
 
         ["Stream.Connecting"] = "Подключение…",
         ["Stream.Reconnecting"] = "Переподключение…",

--- a/src/OpenIPC.Viewer.App/Services/Localizer.cs
+++ b/src/OpenIPC.Viewer.App/Services/Localizer.cs
@@ -368,6 +368,11 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Recordings.Empty"] = "No recordings yet. Hit ● REC on a camera page to start.",
         ["Recordings.Live"] = "live",
         ["Recordings.LoadError"] = "Could not load recordings",
+        ["Recordings.MarkIn"] = "Set In",
+        ["Recordings.MarkOut"] = "Set Out",
+        ["Recordings.Precise"] = "Precise",
+        ["Recordings.Export"] = "Export",
+        ["Recordings.ExportTitle"] = "Export clip",
 
         ["Events.Button.SimulateMotion"] = "Simulate motion",
         ["Events.Empty"] = "No events yet. Hit Simulate motion to push one through the pipeline.",
@@ -689,6 +694,11 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Recordings.Empty"] = "Записей пока нет. Нажмите ● REC на странице камеры, чтобы начать.",
         ["Recordings.Live"] = "идёт",
         ["Recordings.LoadError"] = "Не удалось загрузить записи",
+        ["Recordings.MarkIn"] = "Начало",
+        ["Recordings.MarkOut"] = "Конец",
+        ["Recordings.Precise"] = "Точно",
+        ["Recordings.Export"] = "Экспорт",
+        ["Recordings.ExportTitle"] = "Экспорт клипа",
 
         ["Events.Button.SimulateMotion"] = "Симулировать движение",
         ["Events.Empty"] = "Событий пока нет. Нажмите «Симулировать движение», чтобы прогнать одно через конвейер.",

--- a/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
+++ b/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using OpenIPC.Viewer.App.ViewModels;
+using OpenIPC.Viewer.Core.Archive;
 using OpenIPC.Viewer.Core.Events;
 using OpenIPC.Viewer.Core.Recording;
 using OpenIPC.Viewer.Core.Video;
@@ -11,16 +12,27 @@ public sealed class RecordingPlayerPageFactory
     private readonly IPlaybackEngine _engine;
     private readonly IMediaProbe _probe;
     private readonly IEventRepository _events;
+    private readonly IClipExporter _exporter;
+    private readonly IDialogService _dialogs;
     private readonly ILoggerFactory _loggerFactory;
 
-    public RecordingPlayerPageFactory(IPlaybackEngine engine, IMediaProbe probe, IEventRepository events, ILoggerFactory loggerFactory)
+    public RecordingPlayerPageFactory(
+        IPlaybackEngine engine,
+        IMediaProbe probe,
+        IEventRepository events,
+        IClipExporter exporter,
+        IDialogService dialogs,
+        ILoggerFactory loggerFactory)
     {
         _engine = engine;
         _probe = probe;
         _events = events;
+        _exporter = exporter;
+        _dialogs = dialogs;
         _loggerFactory = loggerFactory;
     }
 
     public RecordingPlayerPageViewModel Create(Recording recording, string cameraName) =>
-        new(recording, cameraName, _engine, _probe, _events, _loggerFactory.CreateLogger<RecordingPlayerPageViewModel>());
+        new(recording, cameraName, _engine, _probe, _events, _exporter, _dialogs,
+            _loggerFactory.CreateLogger<RecordingPlayerPageViewModel>());
 }

--- a/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
+++ b/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using OpenIPC.Viewer.App.ViewModels;
+using OpenIPC.Viewer.Core.Events;
 using OpenIPC.Viewer.Core.Recording;
 using OpenIPC.Viewer.Core.Video;
 
@@ -9,15 +10,17 @@ public sealed class RecordingPlayerPageFactory
 {
     private readonly IPlaybackEngine _engine;
     private readonly IMediaProbe _probe;
+    private readonly IEventRepository _events;
     private readonly ILoggerFactory _loggerFactory;
 
-    public RecordingPlayerPageFactory(IPlaybackEngine engine, IMediaProbe probe, ILoggerFactory loggerFactory)
+    public RecordingPlayerPageFactory(IPlaybackEngine engine, IMediaProbe probe, IEventRepository events, ILoggerFactory loggerFactory)
     {
         _engine = engine;
         _probe = probe;
+        _events = events;
         _loggerFactory = loggerFactory;
     }
 
     public RecordingPlayerPageViewModel Create(Recording recording, string cameraName) =>
-        new(recording, cameraName, _engine, _probe, _loggerFactory.CreateLogger<RecordingPlayerPageViewModel>());
+        new(recording, cameraName, _engine, _probe, _events, _loggerFactory.CreateLogger<RecordingPlayerPageViewModel>());
 }

--- a/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
+++ b/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.App.ViewModels;
+using OpenIPC.Viewer.Core.Recording;
+using OpenIPC.Viewer.Core.Video;
+
+namespace OpenIPC.Viewer.App.Services;
+
+public sealed class RecordingPlayerPageFactory
+{
+    private readonly IPlaybackEngine _engine;
+    private readonly IMediaProbe _probe;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public RecordingPlayerPageFactory(IPlaybackEngine engine, IMediaProbe probe, ILoggerFactory loggerFactory)
+    {
+        _engine = engine;
+        _probe = probe;
+        _loggerFactory = loggerFactory;
+    }
+
+    public RecordingPlayerPageViewModel Create(Recording recording, string cameraName) =>
+        new(recording, cameraName, _engine, _probe, _loggerFactory.CreateLogger<RecordingPlayerPageViewModel>());
+}

--- a/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
+++ b/src/OpenIPC.Viewer.App/Services/RecordingPlayerPageFactory.cs
@@ -14,6 +14,7 @@ public sealed class RecordingPlayerPageFactory
     private readonly IEventRepository _events;
     private readonly IClipExporter _exporter;
     private readonly IDialogService _dialogs;
+    private readonly OpenIPC.Viewer.Core.Platform.IShareService _share;
     private readonly ILoggerFactory _loggerFactory;
 
     public RecordingPlayerPageFactory(
@@ -22,6 +23,7 @@ public sealed class RecordingPlayerPageFactory
         IEventRepository events,
         IClipExporter exporter,
         IDialogService dialogs,
+        OpenIPC.Viewer.Core.Platform.IShareService share,
         ILoggerFactory loggerFactory)
     {
         _engine = engine;
@@ -29,10 +31,11 @@ public sealed class RecordingPlayerPageFactory
         _events = events;
         _exporter = exporter;
         _dialogs = dialogs;
+        _share = share;
         _loggerFactory = loggerFactory;
     }
 
     public RecordingPlayerPageViewModel Create(Recording recording, string cameraName) =>
-        new(recording, cameraName, _engine, _probe, _events, _exporter, _dialogs,
+        new(recording, cameraName, _engine, _probe, _events, _exporter, _dialogs, _share,
             _loggerFactory.CreateLogger<RecordingPlayerPageViewModel>());
 }

--- a/src/OpenIPC.Viewer.App/Themes/Theme.axaml
+++ b/src/OpenIPC.Viewer.App/Themes/Theme.axaml
@@ -62,6 +62,9 @@
   <StreamGeometry x:Key="IconCheck">M20,6 L9,17 L4,12</StreamGeometry>
   <StreamGeometry x:Key="IconChevronRight">M9,18 L15,12 L9,6</StreamGeometry>
   <StreamGeometry x:Key="IconChevronLeft">M15,18 L9,12 L15,6</StreamGeometry>
+  <!-- IconPlay / IconPause — transport for the recordings player (Phase 16). -->
+  <StreamGeometry x:Key="IconPlay">M6,3 L20,12 L6,21 Z</StreamGeometry>
+  <StreamGeometry x:Key="IconPause">M6,4 H10 V20 H6 Z M14,4 H18 V20 H14 Z</StreamGeometry>
   <!-- IconPaste — clipboard-paste. -->
   <StreamGeometry x:Key="IconPaste">M11,14 h10 M16,4 h2 a2,2 0 0 1 2,2 v1.344 M17,18 l4,-4 l-4,-4 M8,4 H6 a2,2 0 0 0 -2,2 v14 a2,2 0 0 0 2,2 h12 a2,2 0 0 0 1.793,-1.113 M9,2 h6 a1,1 0 0 1 1,1 v2 a1,1 0 0 1 -1,1 h-6 a1,1 0 0 1 -1,-1 V3 a1,1 0 0 1 1,-1 Z</StreamGeometry>
 

--- a/src/OpenIPC.Viewer.App/ViewModels/ArchiveCalendarViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/ArchiveCalendarViewModel.cs
@@ -23,6 +23,12 @@ public sealed partial class ArchiveCalendarViewModel : ViewModelBase
     private readonly IEventRepository _events;
     private readonly ILogger<ArchiveCalendarViewModel> _logger;
 
+    // Per-month aggregate cache (Phase 16.3). Flipping months within a session
+    // reuses it; LoadAsync (page re-entry) clears it so new recordings show.
+    private readonly Dictionary<(int Year, int Month), MonthActivity> _cache = new();
+
+    private sealed record MonthActivity(IReadOnlyDictionary<DateTime, DayActivity> Activity, int MaxTotal);
+
     // Fired with the selected local date, or null for "all days".
     public event Action<DateTime?>? DaySelected;
 
@@ -54,27 +60,40 @@ public sealed partial class ArchiveCalendarViewModel : ViewModelBase
     public string MonthLabel =>
         new DateTime(Year, Month, 1).ToString("MMMM yyyy", CultureInfo.CurrentCulture);
 
-    public async Task LoadAsync(CancellationToken ct)
+    // Page-entry refresh: drop cached months so freshly-recorded days appear.
+    public Task LoadAsync(CancellationToken ct)
+    {
+        _cache.Clear();
+        return ShowMonthAsync(ct);
+    }
+
+    private async Task ShowMonthAsync(CancellationToken ct)
     {
         try
         {
-            var tz = TimeZoneInfo.Local;
-            var recordings = await _recordings.ListAsync(cameraId: null, ct).ConfigureAwait(true);
-            // Events since the start of the month (local) minus a day, in UTC.
-            var monthStartUtc = TimeZoneInfo.ConvertTimeToUtc(
-                DateTime.SpecifyKind(new DateTime(Year, Month, 1).AddDays(-1), DateTimeKind.Unspecified), tz);
-            var events = await _events
-                .ListAsync(cameraId: null, kind: null, since: monthStartUtc, limit: 20000, ct)
-                .ConfigureAwait(true);
+            if (!_cache.TryGetValue((Year, Month), out var month))
+            {
+                var tz = TimeZoneInfo.Local;
+                var recordings = await _recordings.ListAsync(cameraId: null, ct).ConfigureAwait(true);
+                // Events since the start of the month (local) minus a day, in UTC.
+                var monthStartUtc = TimeZoneInfo.ConvertTimeToUtc(
+                    DateTime.SpecifyKind(new DateTime(Year, Month, 1).AddDays(-1), DateTimeKind.Unspecified), tz);
+                var events = await _events
+                    .ListAsync(cameraId: null, kind: null, since: monthStartUtc, limit: 20000, ct)
+                    .ConfigureAwait(true);
 
-            var activity = CalendarActivity.ForMonth(
-                Year, Month,
-                recordings.Select(r => r.StartedAt),
-                events.Select(e => e.OccurredAt),
-                tz);
+                var activity = CalendarActivity.ForMonth(
+                    Year, Month,
+                    recordings.Select(r => r.StartedAt),
+                    events.Select(e => e.OccurredAt),
+                    tz);
 
-            var maxTotal = activity.Count == 0 ? 0 : activity.Values.Max(d => d.Total);
-            BuildGrid(activity, maxTotal);
+                var maxTotal = activity.Count == 0 ? 0 : activity.Values.Max(d => d.Total);
+                month = new MonthActivity(activity, maxTotal);
+                _cache[(Year, Month)] = month;
+            }
+
+            BuildGrid(month.Activity, month.MaxTotal);
         }
         catch (Exception ex)
         {
@@ -112,14 +131,14 @@ public sealed partial class ArchiveCalendarViewModel : ViewModelBase
     private Task PrevMonthAsync()
     {
         Shift(-1);
-        return LoadAsync(CancellationToken.None);
+        return ShowMonthAsync(CancellationToken.None); // cached
     }
 
     [RelayCommand]
     private Task NextMonthAsync()
     {
         Shift(1);
-        return LoadAsync(CancellationToken.None);
+        return ShowMonthAsync(CancellationToken.None); // cached
     }
 
     private void Shift(int months)

--- a/src/OpenIPC.Viewer.App/ViewModels/ArchiveCalendarViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/ArchiveCalendarViewModel.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.Core.Archive;
+using OpenIPC.Viewer.Core.Events;
+using OpenIPC.Viewer.Core.Recording;
+
+namespace OpenIPC.Viewer.App.ViewModels;
+
+// Archive month calendar (Phase 16.3). Highlights days with recordings/events
+// (intensity ∝ volume) and raises DaySelected so the recordings list filters to
+// the chosen local day. Aggregates are recomputed per visible month.
+public sealed partial class ArchiveCalendarViewModel : ViewModelBase
+{
+    private readonly IRecordingRepository _recordings;
+    private readonly IEventRepository _events;
+    private readonly ILogger<ArchiveCalendarViewModel> _logger;
+
+    // Fired with the selected local date, or null for "all days".
+    public event Action<DateTime?>? DaySelected;
+
+    public ArchiveCalendarViewModel(
+        IRecordingRepository recordings,
+        IEventRepository events,
+        ILogger<ArchiveCalendarViewModel> logger)
+    {
+        _recordings = recordings;
+        _events = events;
+        _logger = logger;
+        var now = DateTime.Now;
+        _year = now.Year;
+        _month = now.Month;
+    }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(MonthLabel))]
+    private int _year;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(MonthLabel))]
+    private int _month;
+
+    [ObservableProperty] private DateTime? _selectedDate;
+
+    public ObservableCollection<CalendarDayCell> Days { get; } = new();
+
+    public string MonthLabel =>
+        new DateTime(Year, Month, 1).ToString("MMMM yyyy", CultureInfo.CurrentCulture);
+
+    public async Task LoadAsync(CancellationToken ct)
+    {
+        try
+        {
+            var tz = TimeZoneInfo.Local;
+            var recordings = await _recordings.ListAsync(cameraId: null, ct).ConfigureAwait(true);
+            // Events since the start of the month (local) minus a day, in UTC.
+            var monthStartUtc = TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(new DateTime(Year, Month, 1).AddDays(-1), DateTimeKind.Unspecified), tz);
+            var events = await _events
+                .ListAsync(cameraId: null, kind: null, since: monthStartUtc, limit: 20000, ct)
+                .ConfigureAwait(true);
+
+            var activity = CalendarActivity.ForMonth(
+                Year, Month,
+                recordings.Select(r => r.StartedAt),
+                events.Select(e => e.OccurredAt),
+                tz);
+
+            var maxTotal = activity.Count == 0 ? 0 : activity.Values.Max(d => d.Total);
+            BuildGrid(activity, maxTotal);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load calendar activity for {Year}-{Month}", Year, Month);
+        }
+    }
+
+    private void BuildGrid(IReadOnlyDictionary<DateTime, DayActivity> activity, int maxTotal)
+    {
+        Days.Clear();
+        var first = new DateTime(Year, Month, 1);
+        // Grid starts on the Monday on/before the 1st (ISO week start).
+        var offset = ((int)first.DayOfWeek + 6) % 7; // Mon=0 … Sun=6
+        var gridStart = first.AddDays(-offset);
+        var today = DateTime.Now.Date;
+
+        for (var i = 0; i < 42; i++) // 6 weeks
+        {
+            var date = gridStart.AddDays(i).Date;
+            activity.TryGetValue(date, out var day);
+            var cell = new CalendarDayCell(
+                date,
+                inMonth: date.Month == Month && date.Year == Year,
+                total: day.Total,
+                intensity: CalendarActivity.Intensity(day, maxTotal),
+                isToday: date == today)
+            {
+                IsSelected = SelectedDate is { } sel && sel.Date == date,
+            };
+            Days.Add(cell);
+        }
+    }
+
+    [RelayCommand]
+    private Task PrevMonthAsync()
+    {
+        Shift(-1);
+        return LoadAsync(CancellationToken.None);
+    }
+
+    [RelayCommand]
+    private Task NextMonthAsync()
+    {
+        Shift(1);
+        return LoadAsync(CancellationToken.None);
+    }
+
+    private void Shift(int months)
+    {
+        var d = new DateTime(Year, Month, 1).AddMonths(months);
+        Year = d.Year;
+        Month = d.Month;
+    }
+
+    [RelayCommand]
+    private void SelectDay(CalendarDayCell? cell)
+    {
+        if (cell is null || !cell.HasActivity) return;
+        // Toggle off if the same day is tapped again.
+        if (SelectedDate is { } cur && cur.Date == cell.Date.Date)
+        {
+            SelectedDate = null;
+            foreach (var c in Days) c.IsSelected = false;
+            DaySelected?.Invoke(null);
+            return;
+        }
+        SelectedDate = cell.Date.Date;
+        foreach (var c in Days) c.IsSelected = c.Date.Date == cell.Date.Date;
+        DaySelected?.Invoke(cell.Date.Date);
+    }
+
+    [RelayCommand]
+    private void ShowAll()
+    {
+        SelectedDate = null;
+        foreach (var c in Days) c.IsSelected = false;
+        DaySelected?.Invoke(null);
+    }
+}
+
+public sealed partial class CalendarDayCell : ObservableObject
+{
+    public CalendarDayCell(DateTime date, bool inMonth, int total, double intensity, bool isToday)
+    {
+        Date = date;
+        InMonth = inMonth;
+        Total = total;
+        Intensity = intensity;
+        IsToday = isToday;
+    }
+
+    public DateTime Date { get; }
+    public bool InMonth { get; }
+    public int Total { get; }
+    public double Intensity { get; }
+    public bool IsToday { get; }
+    public bool HasActivity => Total > 0;
+    public string DayNumber => Date.Day.ToString(CultureInfo.CurrentCulture);
+
+    // Accent opacity for the cell: faint days still read as active (floor 0.25);
+    // empty days stay transparent.
+    public double Shade => HasActivity ? Math.Max(0.25, Intensity) : 0.0;
+
+    [ObservableProperty] private bool _isSelected;
+}

--- a/src/OpenIPC.Viewer.App/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/MainWindowViewModel.cs
@@ -11,13 +11,19 @@ using OpenIPC.Viewer.Core.Services;
 
 namespace OpenIPC.Viewer.App.ViewModels;
 
-public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<OpenCameraMessage>, IRecipient<GoBackToLibraryMessage>
+public sealed partial class MainWindowViewModel : ViewModelBase,
+    IRecipient<OpenCameraMessage>,
+    IRecipient<GoBackToLibraryMessage>,
+    IRecipient<OpenRecordingMessage>,
+    IRecipient<GoBackToRecordingsMessage>
 {
     private readonly CameraDirectoryService _directory;
     private readonly SingleCameraPageFactory _singleCameraFactory;
+    private readonly RecordingPlayerPageFactory _playerFactory;
     private readonly ILogger<MainWindowViewModel> _logger;
 
     private SingleCameraPageViewModel? _activeSingleCamera;
+    private RecordingPlayerPageViewModel? _activePlayer;
 
     public GridPageViewModel Live { get; }
     public CameraLibraryPageViewModel Library { get; }
@@ -45,7 +51,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
 
     public bool IsLiveSelected => CurrentPage is GridPageViewModel;
     public bool IsLibrarySelected => CurrentPage is CameraLibraryPageViewModel or SingleCameraPageViewModel;
-    public bool IsRecordingsSelected => CurrentPage is RecordingsPageViewModel;
+    public bool IsRecordingsSelected => CurrentPage is RecordingsPageViewModel or RecordingPlayerPageViewModel;
     public bool IsEventsSelected => CurrentPage is EventsPageViewModel;
     public bool IsAnalyticsSelected => CurrentPage is AnalyticsPageViewModel;
     public bool IsSettingsSelected => CurrentPage is SettingsPageViewModel;
@@ -59,6 +65,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
         SettingsPageViewModel settings,
         CameraDirectoryService directory,
         SingleCameraPageFactory singleCameraFactory,
+        RecordingPlayerPageFactory playerFactory,
         ILogger<MainWindowViewModel> logger)
     {
         Live = live;
@@ -69,11 +76,14 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
         Settings = settings;
         _directory = directory;
         _singleCameraFactory = singleCameraFactory;
+        _playerFactory = playerFactory;
         _logger = logger;
         _currentPage = library;
 
         WeakReferenceMessenger.Default.Register<OpenCameraMessage>(this);
         WeakReferenceMessenger.Default.Register<GoBackToLibraryMessage>(this);
+        WeakReferenceMessenger.Default.Register<OpenRecordingMessage>(this);
+        WeakReferenceMessenger.Default.Register<GoBackToRecordingsMessage>(this);
 
         // While a mobile overlay dialog is open the bottom nav must not switch
         // pages under it — the dim layer doesn't reliably swallow those taps.
@@ -111,6 +121,11 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
     {
         if (_activeSingleCamera is not null && target != "library")
             _ = DisposeActiveSingleCameraAsync();
+
+        // The recordings player lives under the Recordings tab; any nav (incl.
+        // tapping Recordings again) returns to the list and tears it down.
+        if (_activePlayer is not null)
+            _ = DisposeActivePlayerAsync();
 
         CurrentPage = target switch
         {
@@ -151,6 +166,26 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
         CurrentPage = Library;
     }
 
+    public void Receive(OpenRecordingMessage message)
+    {
+        try
+        {
+            _ = DisposeActivePlayerAsync();
+            _activePlayer = _playerFactory.Create(message.Recording, message.CameraName);
+            CurrentPage = _activePlayer;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open recording {Path}", message.Recording.FilePath);
+        }
+    }
+
+    public async void Receive(GoBackToRecordingsMessage message)
+    {
+        await DisposeActivePlayerAsync().ConfigureAwait(true);
+        CurrentPage = Recordings;
+    }
+
     private async Task DisposeActiveSingleCameraAsync()
     {
         if (_activeSingleCamera is null)
@@ -165,6 +200,23 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IRecipient<Open
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error disposing single camera page");
+        }
+    }
+
+    private async Task DisposeActivePlayerAsync()
+    {
+        if (_activePlayer is null)
+            return;
+
+        var vm = _activePlayer;
+        _activePlayer = null;
+        try
+        {
+            await vm.DisposeAsync().ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error disposing recording player page");
         }
     }
 }

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Threading;
@@ -16,6 +17,8 @@ using OpenIPC.Viewer.Core.Timeline;
 using OpenIPC.Viewer.Core.Video;
 
 namespace OpenIPC.Viewer.App.ViewModels;
+
+public enum PlayerEventFilter { All, Motion, Detection }
 
 // Phase 16 — playback of a recorded segment. Hosts an IPlaybackSession (file
 // decode, transport, seek) and exposes it as IVideoSession so the existing
@@ -87,6 +90,23 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     [ObservableProperty] private IReadOnlyList<TimelineSegment>? _segments;
     [ObservableProperty] private IReadOnlyList<TimelineMarker>? _markers;
     [ObservableProperty] private DateTime? _playheadTime;
+
+    // Day event list (16.6): the same motion/detection events as the timeline,
+    // in a clickable side list with a type filter.
+    private readonly List<TimelineMarker> _allEventMarkers = new();
+    public ObservableCollection<TimelineMarker> EventList { get; } = new();
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFilterAll))]
+    [NotifyPropertyChangedFor(nameof(IsFilterMotion))]
+    [NotifyPropertyChangedFor(nameof(IsFilterDetection))]
+    [NotifyPropertyChangedFor(nameof(HasEvents))]
+    private PlayerEventFilter _eventFilter = PlayerEventFilter.All;
+
+    public bool IsFilterAll => EventFilter == PlayerEventFilter.All;
+    public bool IsFilterMotion => EventFilter == PlayerEventFilter.Motion;
+    public bool IsFilterDetection => EventFilter == PlayerEventFilter.Detection;
+    public bool HasEvents => EventList.Count > 0;
 
     public bool IsConnecting => VideoSession is not null && State == SessionState.Connecting;
     public bool IsFailed => State == SessionState.Failed;
@@ -229,11 +249,41 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
                 markers.Add(new TimelineMarker(ev.OccurredAt, kind, label));
             }
             Markers = markers;
+            _allEventMarkers.Clear();
+            _allEventMarkers.AddRange(markers);
+            ApplyEventFilter();
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to load timeline markers for {Path}", _recording.FilePath);
         }
+    }
+
+    [RelayCommand]
+    private void SetEventFilter(string? filter) =>
+        EventFilter = filter switch
+        {
+            "motion" => PlayerEventFilter.Motion,
+            "detection" => PlayerEventFilter.Detection,
+            _ => PlayerEventFilter.All,
+        };
+
+    partial void OnEventFilterChanged(PlayerEventFilter value) => ApplyEventFilter();
+
+    private void ApplyEventFilter()
+    {
+        EventList.Clear();
+        foreach (var m in _allEventMarkers)
+        {
+            var include = EventFilter switch
+            {
+                PlayerEventFilter.Motion => m.Kind == TimelineMarkerKind.Motion,
+                PlayerEventFilter.Detection => m.Kind == TimelineMarkerKind.Detection,
+                _ => true,
+            };
+            if (include) EventList.Add(m);
+        }
+        OnPropertyChanged(nameof(HasEvents));
     }
 
     public async ValueTask DisposeAsync()

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
@@ -34,6 +34,7 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     private readonly IEventRepository _events;
     private readonly IClipExporter _exporter;
     private readonly IDialogService _dialogs;
+    private readonly OpenIPC.Viewer.Core.Platform.IShareService _share;
     private readonly ILogger<RecordingPlayerPageViewModel> _logger;
 
     private IPlaybackSession? _playback;
@@ -50,6 +51,7 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
         IEventRepository events,
         IClipExporter exporter,
         IDialogService dialogs,
+        OpenIPC.Viewer.Core.Platform.IShareService share,
         ILogger<RecordingPlayerPageViewModel> logger)
     {
         _recording = recording;
@@ -59,6 +61,7 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
         _events = events;
         _exporter = exporter;
         _dialogs = dialogs;
+        _share = share;
         _logger = logger;
 
         // Timeline starts as the single recording's span; refined once the exact
@@ -280,6 +283,11 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
             var progress = new Progress<double>(p => ExportFraction = p);
             await _exporter.ExportAsync(request, progress, CancellationToken.None).ConfigureAwait(true);
             ExportStatus = Path.GetFileName(dest);
+
+            // On mobile the picked file is invisible to the user, so hand the
+            // clip to the native share sheet (Phase 16.5 "в галерею/share").
+            if (_share.SupportsSystemShare)
+                await _share.ShareFileAsync(dest!, "video/mp4", CancellationToken.None).ConfigureAwait(true);
         }
         catch (Exception ex)
         {

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.App.Messages;
+using OpenIPC.Viewer.Core.Recording;
+using OpenIPC.Viewer.Core.Video;
+
+namespace OpenIPC.Viewer.App.ViewModels;
+
+// Phase 16 — playback of a recorded segment. Hosts an IPlaybackSession (file
+// decode, transport, seek) and exposes it as IVideoSession so the existing
+// RtspVideoView renders frames unchanged. The timeline/calendar/export layers
+// (Slices C–F) grow on top of this page.
+public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsyncDisposable
+{
+    private readonly Recording _recording;
+    private readonly IPlaybackEngine _engine;
+    private readonly IMediaProbe _probe;
+    private readonly ILogger<RecordingPlayerPageViewModel> _logger;
+
+    private IPlaybackSession? _playback;
+    private IDisposable? _stateSub;
+    private IDisposable? _positionSub;
+    private bool _activating;
+    private bool _disposed;
+
+    public RecordingPlayerPageViewModel(
+        Recording recording,
+        string cameraName,
+        IPlaybackEngine engine,
+        IMediaProbe probe,
+        ILogger<RecordingPlayerPageViewModel> logger)
+    {
+        _recording = recording;
+        CameraName = cameraName;
+        _engine = engine;
+        _probe = probe;
+        _logger = logger;
+    }
+
+    public string Title => Path.GetFileName(_recording.FilePath);
+    public string CameraName { get; }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsConnecting))]
+    [NotifyPropertyChangedFor(nameof(IsFailed))]
+    [NotifyPropertyChangedFor(nameof(IsPlaying))]
+    private SessionState _state = SessionState.Idle;
+
+    [ObservableProperty] private IVideoSession? _videoSession;
+    [ObservableProperty] private string? _errorMessage;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PositionLabel))]
+    private TimeSpan _position;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DurationLabel))]
+    [NotifyPropertyChangedFor(nameof(DurationSeconds))]
+    private TimeSpan _duration;
+
+    public bool IsConnecting => VideoSession is not null && State == SessionState.Connecting;
+    public bool IsFailed => State == SessionState.Failed;
+    public bool IsPlaying => State == SessionState.Playing;
+
+    public string PositionLabel => Format(Position);
+    public string DurationLabel => Format(Duration);
+    public double DurationSeconds => Duration.TotalSeconds;
+
+    // Two-way bound to the seek slider's Value. Incoming playback updates raise
+    // PositionSeconds (via OnPositionChanged) so the thumb tracks; a drag from
+    // the UI lands here and, if it diverges from the playhead by more than a
+    // second, is treated as a seek. The threshold absorbs the rounding churn of
+    // per-frame position pushes so they don't loop back as phantom seeks.
+    public double PositionSeconds
+    {
+        get => Position.TotalSeconds;
+        set
+        {
+            if (Math.Abs(value - Position.TotalSeconds) < 1.0)
+                return;
+            _ = SeekToAsync(TimeSpan.FromSeconds(value));
+        }
+    }
+
+    public async Task ActivateAsync(CancellationToken ct)
+    {
+        if (VideoSession is not null || _activating || _disposed)
+            return;
+        _activating = true;
+        try
+        {
+            // Pre-probe the exact duration so the seek bar has a correct range
+            // before the first frame arrives (16.2 — don't guess the length).
+            try
+            {
+                var info = await _probe.ProbeAsync(_recording.FilePath, ct).ConfigureAwait(true);
+                if (info.Duration > TimeSpan.Zero)
+                    Duration = info.Duration;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Pre-probe failed for {Path}", _recording.FilePath);
+            }
+
+            var session = _engine.OpenFile(PlaybackOptions.Default(_recording.FilePath));
+            _stateSub = session.StateChanged.Subscribe(s => Dispatcher.UIThread.Post(() =>
+            {
+                State = s;
+                if (s == SessionState.Failed)
+                    ErrorMessage = session.LastError;
+            }));
+            _positionSub = session.PositionChanged.Subscribe(p => Dispatcher.UIThread.Post(() =>
+            {
+                Position = p;
+                // Duration is only known after the decode thread probes the file;
+                // adopt it on the first tick that reports a non-zero length.
+                if (session.Duration > TimeSpan.Zero && Duration != session.Duration)
+                    Duration = session.Duration;
+            }));
+            _playback = session;
+            VideoSession = session;
+            await session.StartAsync(ct).ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to open recording {Path}", _recording.FilePath);
+            ErrorMessage = ex.Message;
+            State = SessionState.Failed;
+        }
+        finally
+        {
+            _activating = false;
+        }
+    }
+
+    [RelayCommand]
+    private void PlayPause()
+    {
+        if (_playback is null) return;
+        if (_playback.IsPaused) _playback.Play();
+        else _playback.Pause();
+    }
+
+    [RelayCommand]
+    private Task RestartAsync() => SeekToAsync(TimeSpan.Zero);
+
+    private async Task SeekToAsync(TimeSpan position)
+    {
+        if (_playback is null) return;
+        Position = position; // optimistic — keeps the slider responsive mid-drag
+        try { await _playback.SeekAsync(position, CancellationToken.None).ConfigureAwait(true); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Seek to {Pos} failed", position); }
+    }
+
+    [RelayCommand]
+    private void Back() => WeakReferenceMessenger.Default.Send(new GoBackToRecordingsMessage());
+
+    partial void OnPositionChanged(TimeSpan value) => OnPropertyChanged(nameof(PositionSeconds));
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _stateSub?.Dispose();
+        _positionSub?.Dispose();
+        var session = _playback;
+        _playback = null;
+        VideoSession = null;
+        if (session is not null)
+        {
+            try { await session.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Error disposing playback session"); }
+        }
+    }
+
+    private static string Format(TimeSpan t) =>
+        t.TotalHours >= 1
+            ? string.Format(CultureInfo.InvariantCulture, "{0:D2}:{1:D2}:{2:D2}", (int)t.TotalHours, t.Minutes, t.Seconds)
+            : string.Format(CultureInfo.InvariantCulture, "{0:D2}:{1:D2}", t.Minutes, t.Seconds);
+}

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Threading;
@@ -9,7 +10,9 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using OpenIPC.Viewer.App.Messages;
+using OpenIPC.Viewer.Core.Events;
 using OpenIPC.Viewer.Core.Recording;
+using OpenIPC.Viewer.Core.Timeline;
 using OpenIPC.Viewer.Core.Video;
 
 namespace OpenIPC.Viewer.App.ViewModels;
@@ -23,6 +26,7 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     private readonly Recording _recording;
     private readonly IPlaybackEngine _engine;
     private readonly IMediaProbe _probe;
+    private readonly IEventRepository _events;
     private readonly ILogger<RecordingPlayerPageViewModel> _logger;
 
     private IPlaybackSession? _playback;
@@ -36,13 +40,23 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
         string cameraName,
         IPlaybackEngine engine,
         IMediaProbe probe,
+        IEventRepository events,
         ILogger<RecordingPlayerPageViewModel> logger)
     {
         _recording = recording;
         CameraName = cameraName;
         _engine = engine;
         _probe = probe;
+        _events = events;
         _logger = logger;
+
+        // Timeline starts as the single recording's span; refined once the exact
+        // duration is probed. Times are UTC (the control formats to local).
+        TimelineStart = recording.StartedAt;
+        TimelineEnd = recording.EndedAt is { } e && e > recording.StartedAt
+            ? e
+            : recording.StartedAt.AddMinutes(1);
+        Segments = new[] { new TimelineSegment(TimelineStart, TimelineEnd) };
     }
 
     public string Title => Path.GetFileName(_recording.FilePath);
@@ -65,6 +79,14 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     [NotifyPropertyChangedFor(nameof(DurationLabel))]
     [NotifyPropertyChangedFor(nameof(DurationSeconds))]
     private TimeSpan _duration;
+
+    // Timeline (16.4): absolute-time track range, segments, event markers, and
+    // the playhead as an absolute time derived from Position.
+    [ObservableProperty] private DateTime _timelineStart;
+    [ObservableProperty] private DateTime _timelineEnd;
+    [ObservableProperty] private IReadOnlyList<TimelineSegment>? _segments;
+    [ObservableProperty] private IReadOnlyList<TimelineMarker>? _markers;
+    [ObservableProperty] private DateTime? _playheadTime;
 
     public bool IsConnecting => VideoSession is not null && State == SessionState.Connecting;
     public bool IsFailed => State == SessionState.Failed;
@@ -110,6 +132,8 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
                 _logger.LogDebug(ex, "Pre-probe failed for {Path}", _recording.FilePath);
             }
 
+            await LoadMarkersAsync(ct).ConfigureAwait(true);
+
             var session = _engine.OpenFile(PlaybackOptions.Default(_recording.FilePath));
             _stateSub = session.StateChanged.Subscribe(s => Dispatcher.UIThread.Post(() =>
             {
@@ -152,6 +176,10 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     [RelayCommand]
     private Task RestartAsync() => SeekToAsync(TimeSpan.Zero);
 
+    // Invoked by the timeline on click/marker-tap with an absolute UTC time.
+    [RelayCommand]
+    private Task SeekToTime(DateTime target) => SeekToAsync(target - TimelineStart);
+
     private async Task SeekToAsync(TimeSpan position)
     {
         if (_playback is null) return;
@@ -163,7 +191,50 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     [RelayCommand]
     private void Back() => WeakReferenceMessenger.Default.Send(new GoBackToRecordingsMessage());
 
-    partial void OnPositionChanged(TimeSpan value) => OnPropertyChanged(nameof(PositionSeconds));
+    partial void OnPositionChanged(TimeSpan value)
+    {
+        OnPropertyChanged(nameof(PositionSeconds));
+        PlayheadTime = TimelineStart + value;
+    }
+
+    partial void OnDurationChanged(TimeSpan value)
+    {
+        if (value <= TimeSpan.Zero) return;
+        TimelineEnd = TimelineStart + value;
+        Segments = new[] { new TimelineSegment(TimelineStart, TimelineEnd) };
+    }
+
+    private async Task LoadMarkersAsync(CancellationToken ct)
+    {
+        try
+        {
+            var list = await _events
+                .ListAsync(_recording.CameraId, kind: null, since: TimelineStart.AddSeconds(-1), limit: 2000, ct)
+                .ConfigureAwait(true);
+
+            var markers = new List<TimelineMarker>();
+            foreach (var ev in list)
+            {
+                if (ev.OccurredAt < TimelineStart || ev.OccurredAt > TimelineEnd)
+                    continue;
+                var kind = ev.Kind switch
+                {
+                    EventKind.Detection => TimelineMarkerKind.Detection,
+                    EventKind.Motion => TimelineMarkerKind.Motion,
+                    _ => TimelineMarkerKind.Other,
+                };
+                if (kind == TimelineMarkerKind.Other)
+                    continue; // only motion/detection belong on the archive track
+                var label = $"{ev.OccurredAt.ToLocalTime():HH:mm:ss} · {ev.Summary ?? kind.ToString()}";
+                markers.Add(new TimelineMarker(ev.OccurredAt, kind, label));
+            }
+            Markers = markers;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to load timeline markers for {Path}", _recording.FilePath);
+        }
+    }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingPlayerPageViewModel.cs
@@ -11,6 +11,8 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using OpenIPC.Viewer.App.Messages;
+using OpenIPC.Viewer.App.Services;
+using OpenIPC.Viewer.Core.Archive;
 using OpenIPC.Viewer.Core.Events;
 using OpenIPC.Viewer.Core.Recording;
 using OpenIPC.Viewer.Core.Timeline;
@@ -30,6 +32,8 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     private readonly IPlaybackEngine _engine;
     private readonly IMediaProbe _probe;
     private readonly IEventRepository _events;
+    private readonly IClipExporter _exporter;
+    private readonly IDialogService _dialogs;
     private readonly ILogger<RecordingPlayerPageViewModel> _logger;
 
     private IPlaybackSession? _playback;
@@ -44,6 +48,8 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
         IPlaybackEngine engine,
         IMediaProbe probe,
         IEventRepository events,
+        IClipExporter exporter,
+        IDialogService dialogs,
         ILogger<RecordingPlayerPageViewModel> logger)
     {
         _recording = recording;
@@ -51,6 +57,8 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
         _engine = engine;
         _probe = probe;
         _events = events;
+        _exporter = exporter;
+        _dialogs = dialogs;
         _logger = logger;
 
         // Timeline starts as the single recording's span; refined once the exact
@@ -107,6 +115,36 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     public bool IsFilterMotion => EventFilter == PlayerEventFilter.Motion;
     public bool IsFilterDetection => EventFilter == PlayerEventFilter.Detection;
     public bool HasEvents => EventList.Count > 0;
+
+    // Clip export (16.5): in/out marks (absolute UTC) on the timeline + state.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSelection))]
+    [NotifyPropertyChangedFor(nameof(SelectionLabel))]
+    [NotifyCanExecuteChangedFor(nameof(ExportCommand))]
+    private DateTime? _selectionStart;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSelection))]
+    [NotifyPropertyChangedFor(nameof(SelectionLabel))]
+    [NotifyCanExecuteChangedFor(nameof(ExportCommand))]
+    private DateTime? _selectionEnd;
+
+    [ObservableProperty] private bool _preciseExport;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(ExportCommand))]
+    private bool _isExporting;
+
+    [ObservableProperty] private double _exportFraction;
+    [ObservableProperty] private string? _exportStatus;
+
+    public bool HasSelection =>
+        SelectionStart is { } s && SelectionEnd is { } e && Math.Abs((e - s).TotalSeconds) >= 0.5;
+
+    public string SelectionLabel =>
+        HasSelection
+            ? $"{Format(Min(SelectionStart!.Value, SelectionEnd!.Value) - TimelineStart)} – {Format(Max(SelectionStart!.Value, SelectionEnd!.Value) - TimelineStart)}"
+            : "—";
 
     public bool IsConnecting => VideoSession is not null && State == SessionState.Connecting;
     public bool IsFailed => State == SessionState.Failed;
@@ -199,6 +237,65 @@ public sealed partial class RecordingPlayerPageViewModel : ViewModelBase, IAsync
     // Invoked by the timeline on click/marker-tap with an absolute UTC time.
     [RelayCommand]
     private Task SeekToTime(DateTime target) => SeekToAsync(target - TimelineStart);
+
+    [RelayCommand]
+    private void SetIn()
+    {
+        if (PlayheadTime is { } t) SelectionStart = t;
+    }
+
+    [RelayCommand]
+    private void SetOut()
+    {
+        if (PlayheadTime is { } t) SelectionEnd = t;
+    }
+
+    [RelayCommand]
+    private void ClearSelection()
+    {
+        SelectionStart = null;
+        SelectionEnd = null;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExport))]
+    private async Task ExportAsync()
+    {
+        var startAbs = Min(SelectionStart!.Value, SelectionEnd!.Value);
+        var endAbs = Max(SelectionStart!.Value, SelectionEnd!.Value);
+        var startOff = startAbs - TimelineStart;
+        if (startOff < TimeSpan.Zero) startOff = TimeSpan.Zero;
+        var endOff = endAbs - TimelineStart;
+
+        var suggested = Path.GetFileNameWithoutExtension(_recording.FilePath) + "_clip.mp4";
+        var dest = await _dialogs.PickSaveFileAsync(suggested, Localizer.Instance["Recordings.ExportTitle"], "mp4")
+            .ConfigureAwait(true);
+        if (string.IsNullOrEmpty(dest)) return;
+
+        IsExporting = true;
+        ExportFraction = 0;
+        ExportStatus = null;
+        try
+        {
+            var request = new ClipExportRequest(_recording.FilePath, dest!, startOff, endOff, PreciseExport);
+            var progress = new Progress<double>(p => ExportFraction = p);
+            await _exporter.ExportAsync(request, progress, CancellationToken.None).ConfigureAwait(true);
+            ExportStatus = Path.GetFileName(dest);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Clip export failed for {Path}", _recording.FilePath);
+            ExportStatus = ex.Message;
+        }
+        finally
+        {
+            IsExporting = false;
+        }
+    }
+
+    private bool CanExport() => HasSelection && !IsExporting;
+
+    private static DateTime Min(DateTime a, DateTime b) => a <= b ? a : b;
+    private static DateTime Max(DateTime a, DateTime b) => a >= b ? a : b;
 
     private async Task SeekToAsync(TimeSpan position)
     {

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingsPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingsPageViewModel.cs
@@ -6,7 +6,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.App.Messages;
 using OpenIPC.Viewer.App.Services;
 using OpenIPC.Viewer.Core.Entities;
 using OpenIPC.Viewer.Core.Recording;
@@ -120,6 +122,13 @@ public sealed partial class RecordingsPageViewModel : ViewModelBase
 
     [RelayCommand]
     private Task ReloadAsync() => LoadAsync(CancellationToken.None);
+
+    [RelayCommand]
+    private void Play(RecordingRowViewModel? row)
+    {
+        if (row is null) return;
+        WeakReferenceMessenger.Default.Send(new OpenRecordingMessage(row.Recording, row.CameraName));
+    }
 
     [RelayCommand]
     private async Task DeleteAsync(RecordingRowViewModel? row)

--- a/src/OpenIPC.Viewer.App/ViewModels/RecordingsPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/RecordingsPageViewModel.cs
@@ -25,7 +25,13 @@ public sealed partial class RecordingsPageViewModel : ViewModelBase
     private readonly IDialogService _dialogs;
     private readonly ILogger<RecordingsPageViewModel> _logger;
 
+    private readonly List<RecordingRowViewModel> _allRows = new();
+    private DateTime? _dayFilter;
+
     public string Title => Localizer.Instance["Nav.Recordings"];
+
+    // Phase 16.3: archive activity calendar. Selecting a day filters the list.
+    public ArchiveCalendarViewModel Calendar { get; }
 
     // Phase 14: the Recordings page doubles as the captured-media browser. A
     // segmented header flips between the recordings list and the snapshot
@@ -69,13 +75,34 @@ public sealed partial class RecordingsPageViewModel : ViewModelBase
         CameraDirectoryService cameras,
         IDialogService dialogs,
         SnapshotBrowserPageViewModel snapshots,
+        ArchiveCalendarViewModel calendar,
         ILogger<RecordingsPageViewModel> logger)
     {
         _repo = repo;
         _cameras = cameras;
         _dialogs = dialogs;
         Snapshots = snapshots;
+        Calendar = calendar;
         _logger = logger;
+        Calendar.DaySelected += OnDaySelected;
+    }
+
+    private void OnDaySelected(DateTime? day)
+    {
+        _dayFilter = day;
+        ApplyFilter();
+    }
+
+    private void ApplyFilter()
+    {
+        Items.Clear();
+        foreach (var row in _allRows)
+        {
+            if (_dayFilter is { } d && row.StartedAtLocal.Date != d.Date)
+                continue;
+            Items.Add(row);
+        }
+        OnPropertyChanged(nameof(IsEmpty));
     }
 
     [RelayCommand]
@@ -100,14 +127,16 @@ public sealed partial class RecordingsPageViewModel : ViewModelBase
             var nameById = new Dictionary<CameraId, string>();
             foreach (var c in cams) nameById[c.Id] = c.Name;
 
-            Items.Clear();
+            _allRows.Clear();
             foreach (var r in recordings)
             {
                 var name = nameById.TryGetValue(r.CameraId, out var n) ? n : Localizer.Instance["Common.Unknown"];
-                Items.Add(new RecordingRowViewModel(r, name));
+                _allRows.Add(new RecordingRowViewModel(r, name));
             }
+            ApplyFilter();
             IsLoaded = true;
-            OnPropertyChanged(nameof(IsEmpty));
+
+            await Calendar.LoadAsync(ct).ConfigureAwait(true);
         }
         catch (Exception ex)
         {
@@ -147,6 +176,7 @@ public sealed partial class RecordingsPageViewModel : ViewModelBase
             catch (IOException ex) { _logger.LogWarning(ex, "File still locked (recording in progress?)"); }
 
             await _repo.RemoveAsync(row.Recording.Id, CancellationToken.None).ConfigureAwait(true);
+            _allRows.Remove(row);
             Items.Remove(row);
             OnPropertyChanged(nameof(IsEmpty));
         }

--- a/src/OpenIPC.Viewer.App/Views/Pages/ArchiveCalendarView.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/ArchiveCalendarView.axaml
@@ -1,0 +1,106 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:OpenIPC.Viewer.App.ViewModels"
+             xmlns:svc="using:OpenIPC.Viewer.App.Services"
+             x:Class="OpenIPC.Viewer.App.Views.Pages.ArchiveCalendarView"
+             x:DataType="vm:ArchiveCalendarViewModel">
+
+  <UserControl.Styles>
+    <Style Selector="Button.nav">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="6,2" />
+      <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}" />
+    </Style>
+    <Style Selector="Button.day">
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Padding" Value="0" />
+      <Setter Property="Margin" Value="1" />
+      <Setter Property="MinHeight" Value="30" />
+      <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+      <Setter Property="VerticalContentAlignment" Value="Stretch" />
+    </Style>
+    <Style Selector="Button.day.outmonth">
+      <Setter Property="Opacity" Value="0.35" />
+    </Style>
+    <Style Selector="Button.day.selected">
+      <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
+    </Style>
+    <Style Selector="Border.today">
+      <Setter Property="BorderBrush" Value="{StaticResource TextSecondaryBrush}" />
+      <Setter Property="BorderThickness" Value="1" />
+    </Style>
+  </UserControl.Styles>
+
+  <StackPanel Spacing="8" Width="240">
+
+    <!-- Month nav -->
+    <Grid ColumnDefinitions="Auto,*,Auto">
+      <Button Grid.Column="0" Classes="nav" Command="{Binding PrevMonthCommand}">
+        <Path Classes="lucide" Data="{StaticResource IconChevronLeft}"
+              Stroke="{StaticResource TextSecondaryBrush}" Width="14" Height="14" />
+      </Button>
+      <TextBlock Grid.Column="1"
+                 Text="{Binding MonthLabel}"
+                 HorizontalAlignment="Center"
+                 VerticalAlignment="Center"
+                 FontWeight="SemiBold"
+                 Foreground="{StaticResource TextPrimaryBrush}" />
+      <Button Grid.Column="2" Classes="nav" Command="{Binding NextMonthCommand}">
+        <Path Classes="lucide" Data="{StaticResource IconChevronRight}"
+              Stroke="{StaticResource TextSecondaryBrush}" Width="14" Height="14" />
+      </Button>
+    </Grid>
+
+    <!-- Weekday header -->
+    <UniformGrid Columns="7">
+      <TextBlock Text="Mon" Classes="wd" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+      <TextBlock Text="Tue" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+      <TextBlock Text="Wed" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+      <TextBlock Text="Thu" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+      <TextBlock Text="Fri" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+      <TextBlock Text="Sat" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+      <TextBlock Text="Sun" HorizontalAlignment="Center" FontSize="10" Foreground="{StaticResource TextTertiaryBrush}" />
+    </UniformGrid>
+
+    <!-- Day grid -->
+    <ItemsControl ItemsSource="{Binding Days}">
+      <ItemsControl.ItemsPanel>
+        <ItemsPanelTemplate>
+          <UniformGrid Columns="7" />
+        </ItemsPanelTemplate>
+      </ItemsControl.ItemsPanel>
+      <ItemsControl.ItemTemplate>
+        <DataTemplate DataType="vm:CalendarDayCell">
+          <Button Classes="day"
+                  Classes.outmonth="{Binding !InMonth}"
+                  Classes.selected="{Binding IsSelected}"
+                  Command="{Binding $parent[ItemsControl].((vm:ArchiveCalendarViewModel)DataContext).SelectDayCommand}"
+                  CommandParameter="{Binding}">
+            <Panel>
+              <Border CornerRadius="4"
+                      Background="{StaticResource AccentBrush}"
+                      Opacity="{Binding Shade}" />
+              <Border Classes.today="{Binding IsToday}" CornerRadius="4" />
+              <TextBlock Text="{Binding DayNumber}"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         FontSize="12"
+                         Foreground="{StaticResource TextPrimaryBrush}" />
+            </Panel>
+          </Button>
+        </DataTemplate>
+      </ItemsControl.ItemTemplate>
+    </ItemsControl>
+
+    <Button Classes="nav"
+            HorizontalAlignment="Center"
+            Command="{Binding ShowAllCommand}"
+            Content="{Binding [Common.All], Source={x:Static svc:Localizer.Instance}}" />
+
+  </StackPanel>
+
+</UserControl>

--- a/src/OpenIPC.Viewer.App/Views/Pages/ArchiveCalendarView.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/Pages/ArchiveCalendarView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace OpenIPC.Viewer.App.Views.Pages;
+
+public sealed partial class ArchiveCalendarView : UserControl
+{
+    public ArchiveCalendarView() => InitializeComponent();
+}

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
@@ -6,6 +6,32 @@
              x:Class="OpenIPC.Viewer.App.Views.Pages.RecordingPlayerPage"
              x:DataType="vm:RecordingPlayerPageViewModel">
 
+  <UserControl.Styles>
+    <Style Selector="Button.evfilter">
+      <Setter Property="Padding" Value="8,3" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="Background" Value="{StaticResource Bg2Brush}" />
+      <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+    <Style Selector="Button.evfilter.active">
+      <Setter Property="Background" Value="{StaticResource AccentBrush}" />
+      <Setter Property="Foreground" Value="White" />
+    </Style>
+    <Style Selector="Button.evrow">
+      <Setter Property="HorizontalAlignment" Value="Stretch" />
+      <Setter Property="HorizontalContentAlignment" Value="Left" />
+      <Setter Property="Background" Value="Transparent" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Padding" Value="10,5" />
+      <Setter Property="CornerRadius" Value="0" />
+    </Style>
+    <Style Selector="Button.evrow:pointerover /template/ ContentPresenter">
+      <Setter Property="Background" Value="{StaticResource Bg2Brush}" />
+    </Style>
+  </UserControl.Styles>
+
   <Grid RowDefinitions="Auto,*,Auto">
 
     <!-- Header: back + file name + camera -->
@@ -33,8 +59,9 @@
       </StackPanel>
     </Grid>
 
-    <!-- Video surface + overlays -->
-    <Grid Grid.Row="1" ClipToBounds="True" Background="Black">
+    <!-- Video surface + overlays (left) + day event list (right) -->
+    <Grid Grid.Row="1" ColumnDefinitions="*,Auto">
+      <Grid Grid.Column="0" ClipToBounds="True" Background="Black">
       <controls:RtspVideoView Session="{Binding VideoSession}" />
 
       <!-- Error strip -->
@@ -61,6 +88,51 @@
                      HorizontalAlignment="Center"
                      IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
         </StackPanel>
+      </Border>
+      </Grid>
+
+      <!-- Day event list (16.6): motion/detection of this recording's window;
+           click an entry to seek; filter by type. -->
+      <Border Grid.Column="1" Width="260" Margin="12,0,0,0"
+              Background="{StaticResource Bg1Brush}"
+              BorderBrush="{StaticResource BorderWeakBrush}"
+              BorderThickness="1"
+              CornerRadius="8">
+        <Grid RowDefinitions="Auto,*">
+          <!-- Type filter -->
+          <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="6" Margin="10,10,10,8">
+            <Button Classes="evfilter" Classes.active="{Binding IsFilterAll}"
+                    Command="{Binding SetEventFilterCommand}" CommandParameter="all" Content="All" />
+            <Button Classes="evfilter" Classes.active="{Binding IsFilterMotion}"
+                    Command="{Binding SetEventFilterCommand}" CommandParameter="motion" Content="Motion" />
+            <Button Classes="evfilter" Classes.active="{Binding IsFilterDetection}"
+                    Command="{Binding SetEventFilterCommand}" CommandParameter="detection" Content="AI" />
+          </StackPanel>
+
+          <TextBlock Grid.Row="1"
+                     IsVisible="{Binding !HasEvents}"
+                     Text="—"
+                     Foreground="{StaticResource TextTertiaryBrush}"
+                     HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+          <ScrollViewer Grid.Row="1" IsVisible="{Binding HasEvents}">
+            <ItemsControl ItemsSource="{Binding EventList}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Button Classes="evrow"
+                          Command="{Binding $parent[ItemsControl].((vm:RecordingPlayerPageViewModel)DataContext).SeekToTimeCommand}"
+                          CommandParameter="{Binding Time}">
+                    <TextBlock Text="{Binding Label}"
+                               FontFamily="{StaticResource FontMono}"
+                               FontSize="11"
+                               TextTrimming="CharacterEllipsis"
+                               Foreground="{StaticResource TextSecondaryBrush}" />
+                  </Button>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </ScrollViewer>
+        </Grid>
       </Border>
     </Grid>
 

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
@@ -148,6 +148,8 @@
                                 Markers="{Binding Markers}"
                                 Position="{Binding PlayheadTime}"
                                 SeekCommand="{Binding SeekToTimeCommand}"
+                                SelectionStart="{Binding SelectionStart, Mode=TwoWay}"
+                                SelectionEnd="{Binding SelectionEnd, Mode=TwoWay}"
                                 TrackBrush="{StaticResource Bg2Brush}"
                                 SegmentBrush="{StaticResource Bg3Brush}"
                                 PlayheadBrush="{StaticResource AccentBrush}"
@@ -195,6 +197,51 @@
           <Path Classes="lucide" Data="{StaticResource IconChevronLeft}"
                 Stroke="{StaticResource TextPrimaryBrush}" Width="16" Height="16" />
         </Button>
+      </Grid>
+
+      <!-- Export bar (16.5): mark in/out, choose precise vs fast copy, export -->
+      <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto" >
+        <Button Grid.Column="0"
+                Command="{Binding SetInCommand}"
+                Content="{Binding [Recordings.MarkIn], Source={x:Static svc:Localizer.Instance}}"
+                Background="Transparent" BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
+                CornerRadius="6" Padding="10,5" FontSize="11" Margin="0,0,6,0"
+                Foreground="{StaticResource TextPrimaryBrush}" />
+        <Button Grid.Column="1"
+                Command="{Binding SetOutCommand}"
+                Content="{Binding [Recordings.MarkOut], Source={x:Static svc:Localizer.Instance}}"
+                Background="Transparent" BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
+                CornerRadius="6" Padding="10,5" FontSize="11" Margin="0,0,6,0"
+                Foreground="{StaticResource TextPrimaryBrush}" />
+        <Button Grid.Column="2"
+                Command="{Binding ClearSelectionCommand}"
+                IsVisible="{Binding HasSelection}"
+                Content="{Binding [Common.Close], Source={x:Static svc:Localizer.Instance}}"
+                Background="Transparent" BorderThickness="0"
+                CornerRadius="6" Padding="8,5" FontSize="11"
+                Foreground="{StaticResource TextSecondaryBrush}" />
+
+        <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center" Margin="12,0">
+          <TextBlock Text="{Binding SelectionLabel}"
+                     FontFamily="{StaticResource FontMono}" FontSize="11"
+                     Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" />
+          <ProgressBar Width="120" Minimum="0" Maximum="1" Value="{Binding ExportFraction}"
+                       IsVisible="{Binding IsExporting}" VerticalAlignment="Center" />
+          <TextBlock Text="{Binding ExportStatus}"
+                     IsVisible="{Binding ExportStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                     FontSize="11" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" />
+        </StackPanel>
+
+        <CheckBox Grid.Column="4"
+                  IsChecked="{Binding PreciseExport, Mode=TwoWay}"
+                  Content="{Binding [Recordings.Precise], Source={x:Static svc:Localizer.Instance}}"
+                  FontSize="11" VerticalAlignment="Center" Margin="0,0,8,0"
+                  Foreground="{StaticResource TextSecondaryBrush}" />
+        <Button Grid.Column="5"
+                Command="{Binding ExportCommand}"
+                Content="{Binding [Recordings.Export], Source={x:Static svc:Localizer.Instance}}"
+                Background="{StaticResource AccentBrush}" Foreground="White"
+                CornerRadius="6" Padding="14,5" FontSize="11" />
       </Grid>
     </StackPanel>
 

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
@@ -1,0 +1,120 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:OpenIPC.Viewer.App.ViewModels"
+             xmlns:controls="using:OpenIPC.Viewer.App.Controls"
+             xmlns:svc="using:OpenIPC.Viewer.App.Services"
+             x:Class="OpenIPC.Viewer.App.Views.Pages.RecordingPlayerPage"
+             x:DataType="vm:RecordingPlayerPageViewModel">
+
+  <Grid RowDefinitions="Auto,*,Auto">
+
+    <!-- Header: back + file name + camera -->
+    <Grid Grid.Row="0" ColumnDefinitions="Auto,*" Margin="0,0,0,12">
+      <Button Grid.Column="0"
+              Command="{Binding BackCommand}"
+              Background="Transparent"
+              BorderBrush="{StaticResource BorderMediumBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="8,6"
+              VerticalAlignment="Center">
+        <Path Classes="lucide" Data="{StaticResource IconChevronLeft}"
+              Stroke="{StaticResource TextPrimaryBrush}" Width="16" Height="16" />
+      </Button>
+      <StackPanel Grid.Column="1" Spacing="2" Margin="16,0,0,0" VerticalAlignment="Center">
+        <TextBlock Text="{Binding Title}"
+                   FontFamily="{StaticResource FontMono}"
+                   FontSize="{StaticResource FontSizeLg}"
+                   FontWeight="SemiBold"
+                   Foreground="{StaticResource TextPrimaryBrush}" />
+        <TextBlock Text="{Binding CameraName}"
+                   FontSize="{StaticResource FontSizeSm}"
+                   Foreground="{StaticResource TextSecondaryBrush}" />
+      </StackPanel>
+    </Grid>
+
+    <!-- Video surface + overlays -->
+    <Grid Grid.Row="1" ClipToBounds="True" Background="Black">
+      <controls:RtspVideoView Session="{Binding VideoSession}" />
+
+      <!-- Error strip -->
+      <Border HorizontalAlignment="Stretch" VerticalAlignment="Top"
+              Background="{StaticResource DangerBrush}"
+              Padding="12,8"
+              IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+        <TextBlock Text="{Binding ErrorMessage}" Foreground="White" TextWrapping="Wrap" />
+      </Border>
+
+      <!-- Failed overlay -->
+      <Border IsVisible="{Binding IsFailed}" Background="#A0000000">
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12" MaxWidth="420">
+          <TextBlock Text="{Binding [Stream.Disconnected], Source={x:Static svc:Localizer.Instance}}"
+                     Foreground="White"
+                     FontSize="{StaticResource FontSizeLg}"
+                     FontWeight="SemiBold"
+                     HorizontalAlignment="Center" />
+          <TextBlock Text="{Binding ErrorMessage}"
+                     Foreground="{StaticResource TextSecondaryBrush}"
+                     FontSize="{StaticResource FontSizeBase}"
+                     TextWrapping="Wrap"
+                     TextAlignment="Center"
+                     HorizontalAlignment="Center"
+                     IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+        </StackPanel>
+      </Border>
+    </Grid>
+
+    <!-- Transport bar: play/pause · position · seek · duration · restart -->
+    <Grid Grid.Row="2" ColumnDefinitions="Auto,Auto,*,Auto,Auto" Margin="0,12,0,0">
+      <Button Grid.Column="0"
+              Command="{Binding PlayPauseCommand}"
+              Background="{StaticResource AccentBrush}"
+              CornerRadius="6"
+              Padding="10,8"
+              VerticalAlignment="Center">
+        <Panel>
+          <Path Classes="lucide" Data="{StaticResource IconPause}" Stroke="White" Width="16" Height="16"
+                IsVisible="{Binding IsPlaying}" />
+          <Path Classes="lucide" Data="{StaticResource IconPlay}" Stroke="White" Width="16" Height="16"
+                IsVisible="{Binding !IsPlaying}" />
+        </Panel>
+      </Button>
+
+      <TextBlock Grid.Column="1"
+                 Text="{Binding PositionLabel}"
+                 FontFamily="{StaticResource FontMono}"
+                 FontSize="{StaticResource FontSizeSm}"
+                 Foreground="{StaticResource TextSecondaryBrush}"
+                 VerticalAlignment="Center"
+                 Margin="12,0,12,0" MinWidth="56" />
+
+      <Slider Grid.Column="2"
+              Minimum="0"
+              Maximum="{Binding DurationSeconds}"
+              Value="{Binding PositionSeconds, Mode=TwoWay}"
+              VerticalAlignment="Center" />
+
+      <TextBlock Grid.Column="3"
+                 Text="{Binding DurationLabel}"
+                 FontFamily="{StaticResource FontMono}"
+                 FontSize="{StaticResource FontSizeSm}"
+                 Foreground="{StaticResource TextSecondaryBrush}"
+                 VerticalAlignment="Center"
+                 Margin="12,0,12,0" MinWidth="56" />
+
+      <Button Grid.Column="4"
+              Command="{Binding RestartCommand}"
+              Background="Transparent"
+              BorderBrush="{StaticResource BorderMediumBrush}"
+              BorderThickness="1"
+              CornerRadius="6"
+              Padding="8,8"
+              VerticalAlignment="Center">
+        <Path Classes="lucide" Data="{StaticResource IconChevronLeft}"
+              Stroke="{StaticResource TextPrimaryBrush}" Width="16" Height="16" />
+      </Button>
+    </Grid>
+
+  </Grid>
+
+</UserControl>

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
@@ -64,56 +64,67 @@
       </Border>
     </Grid>
 
-    <!-- Transport bar: play/pause · position · seek · duration · restart -->
-    <Grid Grid.Row="2" ColumnDefinitions="Auto,Auto,*,Auto,Auto" Margin="0,12,0,0">
-      <Button Grid.Column="0"
-              Command="{Binding PlayPauseCommand}"
-              Background="{StaticResource AccentBrush}"
-              CornerRadius="6"
-              Padding="10,8"
-              VerticalAlignment="Center">
-        <Panel>
-          <Path Classes="lucide" Data="{StaticResource IconPause}" Stroke="White" Width="16" Height="16"
-                IsVisible="{Binding IsPlaying}" />
-          <Path Classes="lucide" Data="{StaticResource IconPlay}" Stroke="White" Width="16" Height="16"
-                IsVisible="{Binding !IsPlaying}" />
-        </Panel>
-      </Button>
+    <!-- Timeline + transport bar -->
+    <StackPanel Grid.Row="2" Spacing="8" Margin="0,12,0,0">
 
-      <TextBlock Grid.Column="1"
-                 Text="{Binding PositionLabel}"
-                 FontFamily="{StaticResource FontMono}"
-                 FontSize="{StaticResource FontSizeSm}"
-                 Foreground="{StaticResource TextSecondaryBrush}"
-                 VerticalAlignment="Center"
-                 Margin="12,0,12,0" MinWidth="56" />
+      <!-- Canvas timeline: segments + motion/detection markers, wheel-zoom to
+           cursor, click/marker-tap to seek (16.4). -->
+      <controls:TimelineControl Height="60"
+                                TotalStart="{Binding TimelineStart}"
+                                TotalEnd="{Binding TimelineEnd}"
+                                Segments="{Binding Segments}"
+                                Markers="{Binding Markers}"
+                                Position="{Binding PlayheadTime}"
+                                SeekCommand="{Binding SeekToTimeCommand}"
+                                TrackBrush="{StaticResource Bg2Brush}"
+                                SegmentBrush="{StaticResource Bg3Brush}"
+                                PlayheadBrush="{StaticResource AccentBrush}"
+                                LabelBrush="{StaticResource TextSecondaryBrush}" />
 
-      <Slider Grid.Column="2"
-              Minimum="0"
-              Maximum="{Binding DurationSeconds}"
-              Value="{Binding PositionSeconds, Mode=TwoWay}"
-              VerticalAlignment="Center" />
+      <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto">
+        <Button Grid.Column="0"
+                Command="{Binding PlayPauseCommand}"
+                Background="{StaticResource AccentBrush}"
+                CornerRadius="6"
+                Padding="10,8"
+                VerticalAlignment="Center">
+          <Panel>
+            <Path Classes="lucide" Data="{StaticResource IconPause}" Stroke="White" Width="16" Height="16"
+                  IsVisible="{Binding IsPlaying}" />
+            <Path Classes="lucide" Data="{StaticResource IconPlay}" Stroke="White" Width="16" Height="16"
+                  IsVisible="{Binding !IsPlaying}" />
+          </Panel>
+        </Button>
 
-      <TextBlock Grid.Column="3"
-                 Text="{Binding DurationLabel}"
-                 FontFamily="{StaticResource FontMono}"
-                 FontSize="{StaticResource FontSizeSm}"
-                 Foreground="{StaticResource TextSecondaryBrush}"
-                 VerticalAlignment="Center"
-                 Margin="12,0,12,0" MinWidth="56" />
+        <TextBlock Grid.Column="1"
+                   Text="{Binding PositionLabel}"
+                   FontFamily="{StaticResource FontMono}"
+                   FontSize="{StaticResource FontSizeSm}"
+                   Foreground="{StaticResource TextSecondaryBrush}"
+                   VerticalAlignment="Center"
+                   Margin="12,0,0,0" MinWidth="56" />
 
-      <Button Grid.Column="4"
-              Command="{Binding RestartCommand}"
-              Background="Transparent"
-              BorderBrush="{StaticResource BorderMediumBrush}"
-              BorderThickness="1"
-              CornerRadius="6"
-              Padding="8,8"
-              VerticalAlignment="Center">
-        <Path Classes="lucide" Data="{StaticResource IconChevronLeft}"
-              Stroke="{StaticResource TextPrimaryBrush}" Width="16" Height="16" />
-      </Button>
-    </Grid>
+        <TextBlock Grid.Column="3"
+                   Text="{Binding DurationLabel}"
+                   FontFamily="{StaticResource FontMono}"
+                   FontSize="{StaticResource FontSizeSm}"
+                   Foreground="{StaticResource TextSecondaryBrush}"
+                   VerticalAlignment="Center"
+                   Margin="0,0,12,0" MinWidth="56" />
+
+        <Button Grid.Column="4"
+                Command="{Binding RestartCommand}"
+                Background="Transparent"
+                BorderBrush="{StaticResource BorderMediumBrush}"
+                BorderThickness="1"
+                CornerRadius="6"
+                Padding="8,8"
+                VerticalAlignment="Center">
+          <Path Classes="lucide" Data="{StaticResource IconChevronLeft}"
+                Stroke="{StaticResource TextPrimaryBrush}" Width="16" Height="16" />
+        </Button>
+      </Grid>
+    </StackPanel>
 
   </Grid>
 

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using OpenIPC.Viewer.App.ViewModels;
+
+namespace OpenIPC.Viewer.App.Views.Pages;
+
+public sealed partial class RecordingPlayerPage : UserControl
+{
+    public RecordingPlayerPage()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
+    }
+
+    private RecordingPlayerPageViewModel? Vm => DataContext as RecordingPlayerPageViewModel;
+
+    private async void OnLoaded(object? sender, RoutedEventArgs e)
+    {
+        if (Vm is { } vm)
+            await vm.ActivateAsync(CancellationToken.None);
+    }
+
+    private async void OnUnloaded(object? sender, RoutedEventArgs e)
+    {
+        // Page VM is owned by MainWindowViewModel, which disposes it on
+        // navigation; Unloaded only fires on teardown, so nothing to do here
+        // beyond the safety net the VM's idempotent DisposeAsync provides.
+        if (Vm is { } vm)
+            await vm.DisposeAsync();
+    }
+}

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingsPage.axaml
@@ -73,7 +73,7 @@
                       BorderThickness="1"
                       CornerRadius="8"
                       Padding="14,10">
-                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
+                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto">
                   <StackPanel Grid.Column="0" Spacing="2">
                     <TextBlock Text="{Binding FileName}"
                                FontFamily="{StaticResource FontMono}"
@@ -110,6 +110,17 @@
                              MinWidth="70" />
 
                   <Button Grid.Column="4"
+                          Padding="10,5"
+                          Background="{StaticResource AccentBrush}"
+                          CornerRadius="4"
+                          Margin="0,0,8,0"
+                          VerticalAlignment="Center"
+                          Command="{Binding $parent[ItemsControl].((vm:RecordingsPageViewModel)DataContext).PlayCommand}"
+                          CommandParameter="{Binding}">
+                    <Path Classes="lucide" Data="{StaticResource IconPlay}" Stroke="White" Width="13" Height="13" />
+                  </Button>
+
+                  <Button Grid.Column="5"
                           Content="{Binding [Common.Delete], Source={x:Static svc:Localizer.Instance}}"
                           Padding="10,4"
                           FontSize="11"

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingsPage.axaml
@@ -48,18 +48,25 @@
       <pages:SnapshotBrowserView DataContext="{Binding Snapshots}" />
     </ContentControl>
 
-    <!-- Recordings tab -->
-    <Grid Grid.Row="1" IsVisible="{Binding ShowRecordings}">
+    <!-- Recordings tab: calendar (left) + list (right) -->
+    <Grid Grid.Row="1" IsVisible="{Binding ShowRecordings}" ColumnDefinitions="Auto,*">
+
+      <!-- Activity calendar -->
+      <pages:ArchiveCalendarView Grid.Column="0"
+                                 DataContext="{Binding Calendar}"
+                                 Margin="0,0,16,0"
+                                 VerticalAlignment="Top" />
 
       <!-- Empty state -->
-      <TextBlock IsVisible="{Binding IsEmpty}"
+      <TextBlock Grid.Column="1"
+                 IsVisible="{Binding IsEmpty}"
                  Text="{Binding [Recordings.Empty], Source={x:Static svc:Localizer.Instance}}"
                  Foreground="{StaticResource TextSecondaryBrush}"
                  HorizontalAlignment="Center"
                  VerticalAlignment="Center" />
 
       <!-- List -->
-      <ScrollViewer IsVisible="{Binding !IsEmpty}">
+      <ScrollViewer Grid.Column="1" IsVisible="{Binding !IsEmpty}">
         <ItemsControl ItemsSource="{Binding Items}">
           <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
@@ -139,7 +146,8 @@
       </ScrollViewer>
 
       <!-- Error overlay -->
-      <StackPanel IsVisible="{Binding HasLoadError}"
+      <StackPanel Grid.Column="1"
+                  IsVisible="{Binding HasLoadError}"
                   VerticalAlignment="Center"
                   HorizontalAlignment="Center"
                   Spacing="12">
@@ -159,7 +167,8 @@
       </StackPanel>
 
       <!-- Loading overlay (rendered last → on top). -->
-      <StackPanel IsVisible="{Binding IsLoading}"
+      <StackPanel Grid.Column="1"
+                  IsVisible="{Binding IsLoading}"
                   VerticalAlignment="Center"
                   HorizontalAlignment="Center"
                   Spacing="12">

--- a/src/OpenIPC.Viewer.Composition/SharedComposition.cs
+++ b/src/OpenIPC.Viewer.Composition/SharedComposition.cs
@@ -135,6 +135,7 @@ public static class SharedComposition
         services.AddSingleton<MainWindowViewModel>();
         services.AddSingleton<GridPageViewModel>();
         services.AddSingleton<CameraLibraryPageViewModel>();
+        services.AddSingleton<ArchiveCalendarViewModel>();
         services.AddSingleton<RecordingsPageViewModel>();
         services.AddSingleton<SnapshotBrowserPageViewModel>();
         services.AddSingleton<EventsPageViewModel>();

--- a/src/OpenIPC.Viewer.Composition/SharedComposition.cs
+++ b/src/OpenIPC.Viewer.Composition/SharedComposition.cs
@@ -59,8 +59,9 @@ public static class SharedComposition
         services.AddSingleton<IPlaybackEngine>(sp =>
             (IPlaybackEngine)sp.GetRequiredService<IVideoEngine>());
         services.AddSingleton<IMediaProbe, OpenIPC.Viewer.Video.Pipeline.FfmpegMediaProbe>();
-        services.AddSingleton<OpenIPC.Viewer.Core.Archive.IClipExporter,
-            OpenIPC.Viewer.Video.Recording.FfmpegSubprocessClipExporter>();
+        // IClipExporter (Phase 16.5) is registered per head: ffmpeg subprocess on
+        // desktop, in-process libavformat on Android/iOS (no exec in the sandbox)
+        // — same split as IRecorder.
         services.AddSingleton<LiveStreamCoordinator>();
 
         // ONVIF

--- a/src/OpenIPC.Viewer.Composition/SharedComposition.cs
+++ b/src/OpenIPC.Viewer.Composition/SharedComposition.cs
@@ -59,6 +59,8 @@ public static class SharedComposition
         services.AddSingleton<IPlaybackEngine>(sp =>
             (IPlaybackEngine)sp.GetRequiredService<IVideoEngine>());
         services.AddSingleton<IMediaProbe, OpenIPC.Viewer.Video.Pipeline.FfmpegMediaProbe>();
+        services.AddSingleton<OpenIPC.Viewer.Core.Archive.IClipExporter,
+            OpenIPC.Viewer.Video.Recording.FfmpegSubprocessClipExporter>();
         services.AddSingleton<LiveStreamCoordinator>();
 
         // ONVIF

--- a/src/OpenIPC.Viewer.Composition/SharedComposition.cs
+++ b/src/OpenIPC.Viewer.Composition/SharedComposition.cs
@@ -54,6 +54,11 @@ public static class SharedComposition
 
         // Video
         services.AddSingleton<IVideoEngine, OpenIPC.Viewer.Video.FfmpegVideoEngine>();
+        // FfmpegVideoEngine also implements IPlaybackEngine (Phase 16 file
+        // playback) — expose the same singleton under that contract.
+        services.AddSingleton<IPlaybackEngine>(sp =>
+            (IPlaybackEngine)sp.GetRequiredService<IVideoEngine>());
+        services.AddSingleton<IMediaProbe, OpenIPC.Viewer.Video.Pipeline.FfmpegMediaProbe>();
         services.AddSingleton<LiveStreamCoordinator>();
 
         // ONVIF
@@ -103,6 +108,7 @@ public static class SharedComposition
         // UI services
         services.AddSingleton<IDialogService, DialogService>();
         services.AddSingleton<SingleCameraPageFactory>();
+        services.AddSingleton<RecordingPlayerPageFactory>();
         services.AddSingleton<CameraEditorFactory>();
         services.AddSingleton<DiscoveryDialogFactory>();
         services.AddSingleton<ManageGroupsDialogFactory>();

--- a/src/OpenIPC.Viewer.Core/Archive/CalendarActivity.cs
+++ b/src/OpenIPC.Viewer.Core/Archive/CalendarActivity.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenIPC.Viewer.Core.Archive;
+
+// Per-day activity counts for the archive calendar (Phase 16.3). Date is a
+// local calendar day (time component is midnight, Kind Unspecified).
+public readonly record struct DayActivity(DateTime Date, int RecordingCount, int EventCount)
+{
+    public int Total => RecordingCount + EventCount;
+    public bool HasActivity => Total > 0;
+}
+
+// Aggregates recordings + events into per-day counts for one month, in a given
+// time zone. UTC→local conversion is DST-aware (TimeZoneInfo) — the competitor's
+// recurring bug was mixing zones, so the boundary is converted explicitly here.
+public static class CalendarActivity
+{
+    public static IReadOnlyDictionary<DateTime, DayActivity> ForMonth(
+        int year, int month,
+        IEnumerable<DateTime> recordingStartsUtc,
+        IEnumerable<DateTime> eventTimesUtc,
+        TimeZoneInfo timeZone)
+    {
+        var result = new Dictionary<DateTime, DayActivity>();
+
+        void Tally(DateTime utc, bool isRecording)
+        {
+            var asUtc = DateTime.SpecifyKind(utc, DateTimeKind.Utc);
+            var local = TimeZoneInfo.ConvertTimeFromUtc(asUtc, timeZone);
+            if (local.Year != year || local.Month != month)
+                return;
+            var day = local.Date;
+            result.TryGetValue(day, out var cur);
+            result[day] = isRecording
+                ? new DayActivity(day, cur.RecordingCount + 1, cur.EventCount)
+                : new DayActivity(day, cur.RecordingCount, cur.EventCount + 1);
+        }
+
+        foreach (var r in recordingStartsUtc) Tally(r, isRecording: true);
+        foreach (var e in eventTimesUtc) Tally(e, isRecording: false);
+        return result;
+    }
+
+    // Normalized 0..1 intensity of a day's total against the busiest day's total
+    // (for shading). Returns 0 when there's no activity in the set.
+    public static double Intensity(DayActivity day, int maxTotal) =>
+        maxTotal <= 0 ? 0 : Math.Clamp(day.Total / (double)maxTotal, 0.0, 1.0);
+}

--- a/src/OpenIPC.Viewer.Core/Archive/ClipExport.cs
+++ b/src/OpenIPC.Viewer.Core/Archive/ClipExport.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenIPC.Viewer.Core.Archive;
+
+// Clip export request (Phase 16.5). Start/End are offsets from the start of the
+// source file. Precise = re-encode for frame-accurate cuts; otherwise a fast
+// stream-copy snapped to GOP/keyframe boundaries.
+public sealed record ClipExportRequest(
+    string SourcePath,
+    string DestinationPath,
+    TimeSpan Start,
+    TimeSpan End,
+    bool Precise);
+
+public interface IClipExporter
+{
+    // Reports 0..1 progress; throws on failure; respects cancellation.
+    Task ExportAsync(ClipExportRequest request, IProgress<double>? progress, CancellationToken ct);
+}
+
+// Pure boundary math for stream-copy export (Phase 16.5/16.7). A `-c copy` cut
+// can only start on a keyframe, so the real clip begins at the last keyframe at
+// or before the requested in-point (GOP accuracy). Frame-accurate cuts need a
+// re-encode (the "precise" path).
+public static class ClipBounds
+{
+    public static TimeSpan SnapStartToKeyframe(TimeSpan requestedStart, IReadOnlyList<TimeSpan> keyframes)
+    {
+        var best = TimeSpan.Zero;
+        foreach (var kf in keyframes)
+            if (kf <= requestedStart && kf > best)
+                best = kf;
+        return best;
+    }
+
+    public static TimeSpan Duration(TimeSpan start, TimeSpan end) =>
+        end > start ? end - start : TimeSpan.Zero;
+}

--- a/src/OpenIPC.Viewer.Core/Timeline/TimelineModels.cs
+++ b/src/OpenIPC.Viewer.Core/Timeline/TimelineModels.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace OpenIPC.Viewer.Core.Timeline;
+
+// Pure presentation-model types for the archive timeline (Phase 16.4). No UI
+// dependency — the control maps Kind to a brush. Times are UTC; the control
+// formats labels in local time.
+
+public enum TimelineMarkerKind
+{
+    Motion = 0,
+    Detection,
+    Other,
+}
+
+// A recorded span on the track.
+public readonly record struct TimelineSegment(DateTime Start, DateTime End);
+
+// A point event (motion / detection) rendered as a tick the user can click.
+public readonly record struct TimelineMarker(DateTime Time, TimelineMarkerKind Kind, string? Label);

--- a/src/OpenIPC.Viewer.Core/Timeline/TimelineTicks.cs
+++ b/src/OpenIPC.Viewer.Core/Timeline/TimelineTicks.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace OpenIPC.Viewer.Core.Timeline;
+
+// Picks an adaptive label interval for the timeline (Phase 16.4): hours →
+// minutes → seconds as the user zooms. Pure + testable.
+public static class TimelineTicks
+{
+    // "Nice" steps in seconds, ascending: 1s..24h.
+    private static readonly double[] StepsSeconds =
+    {
+        1, 2, 5, 10, 15, 30,
+        60, 120, 300, 600, 900, 1800,
+        3600, 7200, 10800, 21600, 43200, 86400,
+    };
+
+    // Smallest step whose on-screen spacing is at least minSpacingPx.
+    public static TimeSpan ChooseStep(double visibleSeconds, double width, double minSpacingPx = 80)
+    {
+        if (width <= 0 || visibleSeconds <= 0)
+            return TimeSpan.FromSeconds(StepsSeconds[^1]);
+
+        var targetSeconds = visibleSeconds * minSpacingPx / width;
+        foreach (var s in StepsSeconds)
+            if (s >= targetSeconds)
+                return TimeSpan.FromSeconds(s);
+        return TimeSpan.FromSeconds(StepsSeconds[^1]);
+    }
+}

--- a/src/OpenIPC.Viewer.Core/Timeline/TimelineViewport.cs
+++ b/src/OpenIPC.Viewer.Core/Timeline/TimelineViewport.cs
@@ -1,0 +1,86 @@
+using System;
+
+namespace OpenIPC.Viewer.Core.Timeline;
+
+// Maps a visible time window to pixels and back, with cursor-anchored zoom and
+// pan (Phase 16.4). Pure math (doubles + DateTime) so it's unit-testable
+// without a control. All clamping keeps the visible window inside the total
+// range; zoom keeps the time under the anchor pixel fixed.
+public sealed class TimelineViewport
+{
+    // Tightest zoom-in: a 2-second visible window. Prevents div-by-zero and
+    // runaway zoom.
+    public const double MinVisibleSeconds = 2.0;
+
+    public DateTime TotalStart { get; }
+    public DateTime TotalEnd { get; }
+    public DateTime VisibleStart { get; private set; }
+    public DateTime VisibleEnd { get; private set; }
+
+    public TimelineViewport(DateTime totalStart, DateTime totalEnd)
+    {
+        if (totalEnd <= totalStart)
+            totalEnd = totalStart.AddSeconds(MinVisibleSeconds);
+        TotalStart = totalStart;
+        TotalEnd = totalEnd;
+        VisibleStart = totalStart;
+        VisibleEnd = totalEnd;
+    }
+
+    public double TotalSeconds => (TotalEnd - TotalStart).TotalSeconds;
+    public double VisibleSeconds => (VisibleEnd - VisibleStart).TotalSeconds;
+
+    public double TimeToX(DateTime t, double width) =>
+        (t - VisibleStart).TotalSeconds / VisibleSeconds * width;
+
+    public DateTime XToTime(double x, double width)
+    {
+        if (width <= 0) return VisibleStart;
+        return VisibleStart.AddSeconds(x / width * VisibleSeconds);
+    }
+
+    // factor > 1 zooms in (window shrinks), < 1 zooms out. The time under
+    // anchorX stays at anchorX.
+    public void ZoomAt(double anchorX, double width, double factor)
+    {
+        if (width <= 0 || factor <= 0) return;
+        var anchorTime = XToTime(anchorX, width);
+        var newSpan = Math.Clamp(VisibleSeconds / factor, MinVisibleSeconds, TotalSeconds);
+        var frac = Math.Clamp(anchorX / width, 0.0, 1.0);
+        var newStart = anchorTime.AddSeconds(-frac * newSpan);
+        SetWindow(newStart, newSpan);
+    }
+
+    // Pans by a pixel delta: dragging right (positive deltaX) moves the content
+    // right, i.e. the window moves earlier in time.
+    public void Pan(double deltaX, double width)
+    {
+        if (width <= 0) return;
+        var dtSec = deltaX / width * VisibleSeconds;
+        SetWindow(VisibleStart.AddSeconds(-dtSec), VisibleSeconds);
+    }
+
+    public void Reset()
+    {
+        VisibleStart = TotalStart;
+        VisibleEnd = TotalEnd;
+    }
+
+    // Places a window of the given span starting at desiredStart, clamped so it
+    // stays within [TotalStart, TotalEnd]. Span is also clamped to the total.
+    private void SetWindow(DateTime desiredStart, double spanSeconds)
+    {
+        var span = Math.Clamp(spanSeconds, MinVisibleSeconds, TotalSeconds);
+        var start = desiredStart;
+        if (start < TotalStart) start = TotalStart;
+        var end = start.AddSeconds(span);
+        if (end > TotalEnd)
+        {
+            end = TotalEnd;
+            start = end.AddSeconds(-span);
+            if (start < TotalStart) start = TotalStart;
+        }
+        VisibleStart = start;
+        VisibleEnd = end;
+    }
+}

--- a/src/OpenIPC.Viewer.Core/Video/IMediaProbe.cs
+++ b/src/OpenIPC.Viewer.Core/Video/IMediaProbe.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenIPC.Viewer.Core.Video;
+
+// Probes a recorded file's container metadata without decoding (Phase 16.2).
+// Used to get an *accurate* duration/codec instead of guessing from the
+// filename or (EndedAt - StartedAt), which drifts on crash-truncated segments.
+public interface IMediaProbe
+{
+    Task<MediaInfo> ProbeAsync(string filePath, CancellationToken ct);
+}
+
+public readonly record struct MediaInfo(
+    TimeSpan Duration,
+    string? Codec,
+    int Width,
+    int Height);

--- a/src/OpenIPC.Viewer.Core/Video/IPlaybackEngine.cs
+++ b/src/OpenIPC.Viewer.Core/Video/IPlaybackEngine.cs
@@ -1,0 +1,9 @@
+namespace OpenIPC.Viewer.Core.Video;
+
+// Opens recorded files for playback (Phase 16). Kept separate from
+// IVideoEngine so live-only heads aren't forced to implement file playback;
+// the desktop FfmpegVideoEngine implements both.
+public interface IPlaybackEngine
+{
+    IPlaybackSession OpenFile(PlaybackOptions options);
+}

--- a/src/OpenIPC.Viewer.Core/Video/IPlaybackSession.cs
+++ b/src/OpenIPC.Viewer.Core/Video/IPlaybackSession.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OpenIPC.Viewer.Core.Video;
+
+// A playback session over a recorded file (Phase 16). Extends the live
+// IVideoSession (same Frames/State/Telemetry surface, so the existing
+// RtspVideoView renders it unchanged) with transport controls: a known
+// Duration, an observable Position, play/pause, and keyframe seek.
+//
+// Note on pause semantics: Play()/Pause() are *transport* — they advance or
+// freeze the playhead. The inherited PauseDecode()/Resume() remain the Smart
+// Pause hooks (tile hidden); a file player wires them to the same freeze.
+public interface IPlaybackSession : IVideoSession
+{
+    // Total length of the file, probed on StartAsync. TimeSpan.Zero until known.
+    TimeSpan Duration { get; }
+
+    // Current playhead position, also pushed through PositionChanged.
+    TimeSpan Position { get; }
+
+    bool IsPaused { get; }
+
+    IObservable<TimeSpan> PositionChanged { get; }
+
+    void Play();
+    void Pause();
+
+    // Seek to the nearest keyframe at or before the requested position, then
+    // decode forward to it. Idempotent while seeking is in flight (latest wins).
+    Task SeekAsync(TimeSpan position, CancellationToken ct);
+}

--- a/src/OpenIPC.Viewer.Core/Video/PlaybackOptions.cs
+++ b/src/OpenIPC.Viewer.Core/Video/PlaybackOptions.cs
@@ -1,0 +1,13 @@
+namespace OpenIPC.Viewer.Core.Video;
+
+// Options for opening a recorded file for playback (Phase 16). Unlike
+// VideoSessionOptions this carries no network/RTSP knobs — it points at a
+// local segment on disk and lets the engine pace presentation off the file's
+// own timestamps.
+public sealed record PlaybackOptions(
+    string FilePath,
+    HwAccelHint HwAccel)
+{
+    public static PlaybackOptions Default(string filePath) =>
+        new(filePath, HwAccelHint.Auto);
+}

--- a/src/OpenIPC.Viewer.Desktop/Composition.cs
+++ b/src/OpenIPC.Viewer.Desktop/Composition.cs
@@ -50,6 +50,15 @@ internal static class Composition
                 cfg["Recording:FfmpegPath"]);
         });
 
+        // Clip export (Phase 16.5) — ffmpeg subprocess on desktop.
+        services.AddSingleton<OpenIPC.Viewer.Core.Archive.IClipExporter>(sp =>
+        {
+            var cfg = sp.GetRequiredService<IConfiguration>();
+            return new FfmpegSubprocessClipExporter(
+                sp.GetRequiredService<ILoggerFactory>(),
+                cfg["Recording:FfmpegPath"]);
+        });
+
         services.AddSharedServices();
 
         var provider = services.BuildServiceProvider(validateScopes: true);

--- a/src/OpenIPC.Viewer.Video/FfmpegVideoEngine.cs
+++ b/src/OpenIPC.Viewer.Video/FfmpegVideoEngine.cs
@@ -4,7 +4,7 @@ using OpenIPC.Viewer.Video.Pipeline;
 
 namespace OpenIPC.Viewer.Video;
 
-public sealed class FfmpegVideoEngine : IVideoEngine
+public sealed class FfmpegVideoEngine : IVideoEngine, IPlaybackEngine
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly IHwDecoderFactory? _hwFactory;
@@ -24,4 +24,7 @@ public sealed class FfmpegVideoEngine : IVideoEngine
 
         return new AutoReconnectingVideoSession(Create, _loggerFactory.CreateLogger<AutoReconnectingVideoSession>());
     }
+
+    public IPlaybackSession OpenFile(PlaybackOptions options) =>
+        new FfmpegPlaybackSession(options, _loggerFactory.CreateLogger<FfmpegPlaybackSession>());
 }

--- a/src/OpenIPC.Viewer.Video/Pipeline/FfmpegMediaProbe.cs
+++ b/src/OpenIPC.Viewer.Video/Pipeline/FfmpegMediaProbe.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FFmpeg.AutoGen.Abstractions;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.Core.Video;
+
+namespace OpenIPC.Viewer.Video.Pipeline;
+
+// avformat-based probe (Phase 16.2). Opens the container, reads stream info,
+// and returns the exact duration/codec/dimensions — no decoding, no playback.
+// Cross-platform via FFmpeg.AutoGen, same as the rest of the pipeline.
+public sealed class FfmpegMediaProbe : IMediaProbe
+{
+    private readonly ILogger<FfmpegMediaProbe> _logger;
+
+    public FfmpegMediaProbe(ILogger<FfmpegMediaProbe> logger) => _logger = logger;
+
+    public Task<MediaInfo> ProbeAsync(string filePath, CancellationToken ct)
+    {
+        // Native calls block; run off the calling thread.
+        return Task.Run(() => Probe(filePath), ct);
+    }
+
+    private unsafe MediaInfo Probe(string filePath)
+    {
+        FfmpegRuntime.EnsureInitialized();
+
+        AVFormatContext* fmtCtx = null;
+        try
+        {
+            var ret = ffmpeg.avformat_open_input(&fmtCtx, filePath, null, null);
+            FfmpegError.ThrowIfError(ret, "avformat_open_input");
+
+            ret = ffmpeg.avformat_find_stream_info(fmtCtx, null);
+            FfmpegError.ThrowIfError(ret, "avformat_find_stream_info");
+
+            var duration = fmtCtx->duration > 0 && fmtCtx->duration != ffmpeg.AV_NOPTS_VALUE
+                ? TimeSpan.FromSeconds(fmtCtx->duration / (double)ffmpeg.AV_TIME_BASE)
+                : TimeSpan.Zero;
+
+            string? codec = null;
+            int width = 0, height = 0;
+            for (var i = 0; i < (int)fmtCtx->nb_streams; i++)
+            {
+                var par = fmtCtx->streams[i]->codecpar;
+                if (par->codec_type != AVMediaType.AVMEDIA_TYPE_VIDEO)
+                    continue;
+
+                width = par->width;
+                height = par->height;
+                if (duration == TimeSpan.Zero)
+                {
+                    var sd = fmtCtx->streams[i]->duration;
+                    if (sd > 0 && sd != ffmpeg.AV_NOPTS_VALUE)
+                        duration = TimeSpan.FromSeconds(sd * ffmpeg.av_q2d(fmtCtx->streams[i]->time_base));
+                }
+
+                var dec = ffmpeg.avcodec_find_decoder(par->codec_id);
+                if (dec != null)
+                    codec = Marshal.PtrToStringAnsi((IntPtr)dec->name);
+                break;
+            }
+
+            return new MediaInfo(duration, codec, width, height);
+        }
+        finally
+        {
+            if (fmtCtx != null) ffmpeg.avformat_close_input(&fmtCtx);
+        }
+    }
+}

--- a/src/OpenIPC.Viewer.Video/Pipeline/FfmpegPlaybackSession.cs
+++ b/src/OpenIPC.Viewer.Video/Pipeline/FfmpegPlaybackSession.cs
@@ -1,0 +1,467 @@
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Reactive.Subjects;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FFmpeg.AutoGen.Abstractions;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.Core.Video;
+using SkiaSharp;
+
+namespace OpenIPC.Viewer.Video.Pipeline;
+
+// Plays a recorded file (Phase 16). Mirrors FfmpegVideoSession's decode/emit
+// path but for local files: presentation is paced off the file's own PTS so it
+// plays at real-time speed, and it adds transport (play/pause), a probed
+// Duration, an observable Position, and keyframe Seek.
+//
+// Software decode only — a single local playback stream doesn't need the HW
+// path the live grid relies on, and software decode keeps seeking simple
+// (no hwframe transfer / get_format wiring). HW playback decode is a later add.
+internal sealed class FfmpegPlaybackSession : IPlaybackSession
+{
+    private const long NoSeek = long.MinValue;
+
+    private readonly PlaybackOptions _options;
+    private readonly ILogger<FfmpegPlaybackSession> _logger;
+
+    private readonly Subject<VideoFrame> _frames = new();
+    private readonly Subject<SessionState> _stateChanged = new();
+    private readonly Subject<SessionTelemetry> _telemetry = new();
+    private readonly Subject<TimeSpan> _positionChanged = new();
+
+    private readonly object _stateLock = new();
+    private readonly object _snapshotLock = new();
+
+    // Transport gate: signaled = playing, reset = paused. The Run loop parks on
+    // it before reading the next packet, so a paused player burns no CPU while
+    // holding its last frame.
+    private readonly ManualResetEventSlim _playGate = new(false);
+    private volatile bool _paused = true;
+
+    private Thread? _thread;
+    private CancellationTokenSource? _cts;
+    private SessionState _state = SessionState.Idle;
+    private string? _lastError;
+
+    // Latest-wins seek request in TimeSpan.Ticks, or NoSeek. The decode loop
+    // drains it before each packet read; SeekAsync just overwrites it.
+    private long _pendingSeekTicks = NoSeek;
+
+    private long _durationTicks;
+    private long _positionTicks;
+
+    private string? _codecName;
+    private int _width;
+    private int _height;
+    private int _framesDecoded;
+
+    private byte[]? _snapshotBgra;
+    private int _snapshotWidth;
+    private int _snapshotHeight;
+    private int _snapshotStride;
+
+    public FfmpegPlaybackSession(PlaybackOptions options, ILogger<FfmpegPlaybackSession> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    public SessionState State { get { lock (_stateLock) return _state; } }
+    public string? LastError { get { lock (_stateLock) return _lastError; } }
+
+    public IObservable<VideoFrame> Frames => _frames;
+    public IObservable<SessionState> StateChanged => _stateChanged;
+    public IObservable<SessionTelemetry> Telemetry => _telemetry;
+    public IObservable<TimeSpan> PositionChanged => _positionChanged;
+
+    public TimeSpan Duration => TimeSpan.FromTicks(Interlocked.Read(ref _durationTicks));
+    public TimeSpan Position => TimeSpan.FromTicks(Interlocked.Read(ref _positionTicks));
+    public bool IsPaused => _paused;
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        if (_thread is not null)
+            throw new InvalidOperationException("Session already started");
+
+        FfmpegRuntime.EnsureInitialized();
+        SetState(SessionState.Connecting);
+
+        _paused = false;
+        _playGate.Set();
+        _cts = new CancellationTokenSource();
+        _thread = new Thread(Run)
+        {
+            IsBackground = true,
+            Priority = ThreadPriority.AboveNormal,
+            Name = "playback",
+        };
+        _thread.Start();
+        return Task.CompletedTask;
+    }
+
+    public void Play()
+    {
+        if (_thread is null) return;
+        _paused = false;
+        _playGate.Set();
+        SetState(SessionState.Playing);
+    }
+
+    public void Pause()
+    {
+        if (_thread is null) return;
+        _paused = true;
+        _playGate.Reset();
+        SetState(SessionState.Paused);
+    }
+
+    // Smart Pause (Phase 12) maps onto transport pause for a file player.
+    public void PauseDecode() => Pause();
+    public void Resume() => Play();
+
+    public Task SeekAsync(TimeSpan position, CancellationToken ct)
+    {
+        if (_thread is null) return Task.CompletedTask;
+        var clamped = position < TimeSpan.Zero ? TimeSpan.Zero : position;
+        var dur = Duration;
+        if (dur > TimeSpan.Zero && clamped > dur) clamped = dur;
+        // Latest-wins: overwrite any not-yet-processed request, then unpark the
+        // loop so it acts on the seek even while paused (scrubbing shows frames).
+        Interlocked.Exchange(ref _pendingSeekTicks, clamped.Ticks);
+        _playGate.Set();
+        return Task.CompletedTask;
+    }
+
+    public Task<byte[]> SnapshotAsync(SnapshotFormat format, CancellationToken ct)
+    {
+        byte[]? bgra;
+        int w, h, stride;
+        lock (_snapshotLock)
+        {
+            if (_snapshotBgra is null)
+                throw new InvalidOperationException("No frame available yet");
+            bgra = (byte[])_snapshotBgra.Clone();
+            w = _snapshotWidth;
+            h = _snapshotHeight;
+            stride = _snapshotStride;
+        }
+
+        using var bitmap = new SKBitmap(new SKImageInfo(w, h, SKColorType.Bgra8888, SKAlphaType.Premul));
+        Marshal.Copy(bgra, 0, bitmap.GetPixels(), stride * h);
+        using var image = SKImage.FromBitmap(bitmap);
+        var skFormat = format == SnapshotFormat.Png ? SKEncodedImageFormat.Png : SKEncodedImageFormat.Jpeg;
+        using var data = image.Encode(skFormat, quality: 92);
+        return Task.FromResult(data.ToArray());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _cts?.Cancel();
+        _playGate.Set();
+        if (_thread is { IsAlive: true })
+            await Task.Run(() => _thread.Join(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+        _frames.OnCompleted();
+        _stateChanged.OnCompleted();
+        _telemetry.OnCompleted();
+        _positionChanged.OnCompleted();
+        _cts?.Dispose();
+        _playGate.Dispose();
+    }
+
+    private unsafe void Run()
+    {
+        AVFormatContext* fmtCtx = null;
+        AVCodecContext* codecCtx = null;
+        AVFrame* frame = null;
+        AVPacket* packet = null;
+        SwsContext* sws = null;
+        var videoStreamIndex = -1;
+        var swsSrcPixFmt = AVPixelFormat.AV_PIX_FMT_NONE;
+        double timeBase = 0;
+
+        // Real-time presentation clock. Origin is (wall, media) of the first
+        // frame after start/seek/resume; subsequent frames sleep until their
+        // media offset elapses on the wall clock.
+        var clock = Stopwatch.StartNew();
+        var haveClock = false;
+        double wallOriginSec = 0, mediaOriginSec = 0;
+
+        try
+        {
+            fmtCtx = ffmpeg.avformat_alloc_context();
+            var ret = ffmpeg.avformat_open_input(&fmtCtx, _options.FilePath, null, null);
+            FfmpegError.ThrowIfError(ret, "avformat_open_input");
+
+            ret = ffmpeg.avformat_find_stream_info(fmtCtx, null);
+            FfmpegError.ThrowIfError(ret, "avformat_find_stream_info");
+
+            for (var i = 0; i < (int)fmtCtx->nb_streams; i++)
+            {
+                if (fmtCtx->streams[i]->codecpar->codec_type == AVMediaType.AVMEDIA_TYPE_VIDEO)
+                {
+                    videoStreamIndex = i;
+                    break;
+                }
+            }
+            if (videoStreamIndex < 0)
+                throw new InvalidOperationException("No video stream in file");
+
+            var stream = fmtCtx->streams[videoStreamIndex];
+            timeBase = ffmpeg.av_q2d(stream->time_base);
+            SetDuration(fmtCtx, stream);
+
+            var codecpar = stream->codecpar;
+            var codec = ffmpeg.avcodec_find_decoder(codecpar->codec_id);
+            if (codec == null)
+                throw new InvalidOperationException($"No decoder for codec id {codecpar->codec_id}");
+
+            codecCtx = ffmpeg.avcodec_alloc_context3(codec);
+            ret = ffmpeg.avcodec_parameters_to_context(codecCtx, codecpar);
+            FfmpegError.ThrowIfError(ret, "avcodec_parameters_to_context");
+
+            ret = ffmpeg.avcodec_open2(codecCtx, codec, null);
+            FfmpegError.ThrowIfError(ret, "avcodec_open2");
+
+            _width = codecCtx->width;
+            _height = codecCtx->height;
+            _codecName = Marshal.PtrToStringAnsi((IntPtr)codec->name);
+
+            packet = ffmpeg.av_packet_alloc();
+            frame = ffmpeg.av_frame_alloc();
+
+            SetState(SessionState.Playing);
+            var ct = _cts!.Token;
+
+            while (!ct.IsCancellationRequested)
+            {
+                // Park while paused (still serves seeks: SeekAsync sets the gate).
+                if (_paused && Interlocked.Read(ref _pendingSeekTicks) == NoSeek)
+                {
+                    try { _playGate.Wait(ct); }
+                    catch (OperationCanceledException) { break; }
+                    if (ct.IsCancellationRequested) break;
+                    haveClock = false; // rebase clock after a pause
+                }
+
+                var seek = Interlocked.Exchange(ref _pendingSeekTicks, NoSeek);
+                long seekTargetPts = ffmpeg.AV_NOPTS_VALUE;
+                if (seek != NoSeek)
+                {
+                    var target = TimeSpan.FromTicks(seek);
+                    var ts = (long)(target.TotalSeconds / timeBase);
+                    ret = ffmpeg.avformat_seek_file(fmtCtx, videoStreamIndex, long.MinValue, ts, ts, ffmpeg.AVSEEK_FLAG_BACKWARD);
+                    if (ret < 0)
+                        _logger.LogWarning("avformat_seek_file failed: {Err}", FfmpegError.Describe(ret));
+                    ffmpeg.avcodec_flush_buffers(codecCtx);
+                    haveClock = false;
+                    seekTargetPts = ts; // decode-and-drop until we reach the requested point
+                    // After a seek we present one frame even if paused, so the UI
+                    // updates to the new position. Re-park happens next iteration.
+                }
+
+                ret = ffmpeg.av_read_frame(fmtCtx, packet);
+                if (ret < 0)
+                {
+                    if (ret == ffmpeg.AVERROR_EOF)
+                    {
+                        // Hold at end-of-file: freeze on the last frame and park
+                        // until a seek (or dispose) arrives.
+                        SetPosition(Duration);
+                        _paused = true;
+                        _playGate.Reset();
+                        SetState(SessionState.Paused);
+                        continue;
+                    }
+                    _logger.LogWarning("av_read_frame failed: {Err}", FfmpegError.Describe(ret));
+                    break;
+                }
+
+                if (packet->stream_index != videoStreamIndex)
+                {
+                    ffmpeg.av_packet_unref(packet);
+                    continue;
+                }
+
+                ret = ffmpeg.avcodec_send_packet(codecCtx, packet);
+                ffmpeg.av_packet_unref(packet);
+                if (ret < 0 && ret != ffmpeg.AVERROR(ffmpeg.EAGAIN))
+                {
+                    _logger.LogWarning("avcodec_send_packet failed: {Err}", FfmpegError.Describe(ret));
+                    continue;
+                }
+
+                while (!ct.IsCancellationRequested)
+                {
+                    ret = ffmpeg.avcodec_receive_frame(codecCtx, frame);
+                    if (ret == ffmpeg.AVERROR(ffmpeg.EAGAIN) || ret == ffmpeg.AVERROR_EOF)
+                        break;
+                    if (ret < 0)
+                    {
+                        _logger.LogWarning("avcodec_receive_frame failed: {Err}", FfmpegError.Describe(ret));
+                        break;
+                    }
+
+                    var pts = frame->best_effort_timestamp != ffmpeg.AV_NOPTS_VALUE
+                        ? frame->best_effort_timestamp
+                        : frame->pts;
+
+                    // Drop frames between the seek keyframe and the requested
+                    // point so we land precisely on the target.
+                    if (seekTargetPts != ffmpeg.AV_NOPTS_VALUE && pts != ffmpeg.AV_NOPTS_VALUE && pts < seekTargetPts)
+                    {
+                        ffmpeg.av_frame_unref(frame);
+                        continue;
+                    }
+                    var justSeeked = seekTargetPts != ffmpeg.AV_NOPTS_VALUE;
+                    seekTargetPts = ffmpeg.AV_NOPTS_VALUE;
+
+                    var mediaSec = pts != ffmpeg.AV_NOPTS_VALUE ? pts * timeBase : mediaOriginSec;
+
+                    var framePixFmt = (AVPixelFormat)frame->format;
+                    if (sws == null || framePixFmt != swsSrcPixFmt)
+                    {
+                        if (sws != null) ffmpeg.sws_freeContext(sws);
+                        sws = ffmpeg.sws_getContext(
+                            _width, _height, framePixFmt,
+                            _width, _height, AVPixelFormat.AV_PIX_FMT_BGRA,
+                            ffmpeg.SWS_BILINEAR, null, null, null);
+                        if (sws == null)
+                            throw new InvalidOperationException($"sws_getContext returned null for {framePixFmt}");
+                        swsSrcPixFmt = framePixFmt;
+                    }
+
+                    PaceTo(clock, ref haveClock, ref wallOriginSec, ref mediaOriginSec, mediaSec, ct);
+                    if (ct.IsCancellationRequested) break;
+
+                    EmitFrame(sws, frame, mediaSec);
+                    SetPosition(TimeSpan.FromSeconds(mediaSec));
+                    ffmpeg.av_frame_unref(frame);
+
+                    // A seek while paused presents exactly one frame, then re-parks.
+                    if (justSeeked && _paused)
+                    {
+                        _playGate.Reset();
+                        break;
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Playback session loop failed");
+            SetState(SessionState.Failed, ex.Message);
+            return;
+        }
+        finally
+        {
+            if (sws != null) ffmpeg.sws_freeContext(sws);
+            if (frame != null) { var p = frame; ffmpeg.av_frame_free(&p); }
+            if (packet != null) { var p = packet; ffmpeg.av_packet_free(&p); }
+            if (codecCtx != null) { var p = codecCtx; ffmpeg.avcodec_free_context(&p); }
+            if (fmtCtx != null) ffmpeg.avformat_close_input(&fmtCtx);
+        }
+
+        SetState(SessionState.Idle);
+    }
+
+    private unsafe void SetDuration(AVFormatContext* fmtCtx, AVStream* stream)
+    {
+        // Prefer the container duration (AV_TIME_BASE = microseconds); fall back
+        // to the stream's own duration in its time base.
+        long ticks = 0;
+        if (fmtCtx->duration > 0 && fmtCtx->duration != ffmpeg.AV_NOPTS_VALUE)
+            ticks = TimeSpan.FromSeconds(fmtCtx->duration / (double)ffmpeg.AV_TIME_BASE).Ticks;
+        else if (stream->duration > 0 && stream->duration != ffmpeg.AV_NOPTS_VALUE)
+            ticks = TimeSpan.FromSeconds(stream->duration * ffmpeg.av_q2d(stream->time_base)).Ticks;
+        Interlocked.Exchange(ref _durationTicks, ticks);
+    }
+
+    private void PaceTo(Stopwatch clock, ref bool haveClock, ref double wallOriginSec, ref double mediaOriginSec, double mediaSec, CancellationToken ct)
+    {
+        if (!haveClock)
+        {
+            wallOriginSec = clock.Elapsed.TotalSeconds;
+            mediaOriginSec = mediaSec;
+            haveClock = true;
+            return;
+        }
+
+        var targetWall = wallOriginSec + (mediaSec - mediaOriginSec);
+        while (!ct.IsCancellationRequested)
+        {
+            var remaining = targetWall - clock.Elapsed.TotalSeconds;
+            if (remaining <= 0.001) break;
+            // Bail out early if a seek arrives so scrubbing stays responsive.
+            if (Interlocked.Read(ref _pendingSeekTicks) != NoSeek) break;
+            var ms = (int)Math.Min(remaining * 1000, 50);
+            if (ms > 0) Thread.Sleep(ms);
+        }
+    }
+
+    private unsafe void EmitFrame(SwsContext* sws, AVFrame* frame, double mediaSec)
+    {
+        var stride = _width * 4;
+        var bufSize = stride * _height;
+        var bgra = ArrayPool<byte>.Shared.Rent(bufSize);
+        try
+        {
+            fixed (byte* dst = bgra)
+            {
+                var dstData = new byte_ptr4 { [0] = dst };
+                var dstLinesize = new int4 { [0] = stride };
+                ffmpeg.sws_scale(sws, frame->data, frame->linesize, 0, _height, dstData, dstLinesize);
+            }
+
+            UpdateSnapshotBuffer(bgra, stride);
+
+            var ptsMicros = (long)(mediaSec * 1_000_000);
+            var vf = new VideoFrame(bgra, _width, _height, stride, ptsMicros, DateTime.UtcNow);
+            try
+            {
+                _frames.OnNext(vf);
+                Interlocked.Increment(ref _framesDecoded);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Subscriber threw in frame OnNext");
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(bgra);
+        }
+    }
+
+    private void UpdateSnapshotBuffer(byte[] sourceBgra, int stride)
+    {
+        var size = stride * _height;
+        lock (_snapshotLock)
+        {
+            if (_snapshotBgra is null || _snapshotBgra.Length < size)
+                _snapshotBgra = new byte[size];
+            Buffer.BlockCopy(sourceBgra, 0, _snapshotBgra, 0, size);
+            _snapshotWidth = _width;
+            _snapshotHeight = _height;
+            _snapshotStride = stride;
+        }
+    }
+
+    private void SetPosition(TimeSpan position)
+    {
+        Interlocked.Exchange(ref _positionTicks, position.Ticks);
+        _positionChanged.OnNext(position);
+    }
+
+    private void SetState(SessionState newState, string? error = null)
+    {
+        lock (_stateLock)
+        {
+            _state = newState;
+            _lastError = error;
+        }
+        _stateChanged.OnNext(newState);
+    }
+}

--- a/src/OpenIPC.Viewer.Video/Recording/FfmpegRecordingSession.cs
+++ b/src/OpenIPC.Viewer.Video/Recording/FfmpegRecordingSession.cs
@@ -64,8 +64,12 @@ internal sealed partial class FfmpegRecordingSession : IRecordingSession
         psi.ArgumentList.Add("-segment_time"); psi.ArgumentList.Add(((int)_options.SegmentDuration.TotalSeconds).ToString(System.Globalization.CultureInfo.InvariantCulture));
         psi.ArgumentList.Add("-reset_timestamps"); psi.ArgumentList.Add("1");
         psi.ArgumentList.Add("-strftime"); psi.ArgumentList.Add("1");
-        // Fragmented MP4 → kill-survivable segments (phase-06 §"MP4 fragmented vs regular").
-        psi.ArgumentList.Add("-movflags"); psi.ArgumentList.Add("+faststart+frag_keyframe+empty_moov");
+        // Fragmented MP4 → kill-survivable segments (phase-16.1). No +faststart:
+        // it relocates the moov in a second pass over a *finished* file, which a
+        // fragmented (empty_moov) stream doesn't have and which defeats the
+        // play-while-recording / crash-survivable guarantee. default_base_moof
+        // matches the in-process libavformat path and improves player compat.
+        psi.ArgumentList.Add("-movflags"); psi.ArgumentList.Add("+frag_keyframe+empty_moov+default_base_moof");
         psi.ArgumentList.Add(outputPattern);
 
         _proc = Process.Start(psi)

--- a/src/OpenIPC.Viewer.Video/Recording/FfmpegSubprocessClipExporter.cs
+++ b/src/OpenIPC.Viewer.Video/Recording/FfmpegSubprocessClipExporter.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.Core.Archive;
+using OpenIPC.Viewer.Video.Pipeline;
+
+namespace OpenIPC.Viewer.Video.Recording;
+
+// Exports a clip by shelling out to ffmpeg (Phase 16.5) — same strategy and
+// path resolution as FfmpegSubprocessRecorder. Stream-copy by default (fast,
+// GOP-accurate); precise mode re-encodes for a frame-accurate cut.
+public sealed partial class FfmpegSubprocessClipExporter : IClipExporter
+{
+    [GeneratedRegex(@"time=(\d+):(\d{2}):(\d{2})\.(\d+)")]
+    private static partial Regex TimeRegex();
+
+    private readonly ILogger<FfmpegSubprocessClipExporter> _logger;
+    private readonly string _ffmpegPath;
+
+    public FfmpegSubprocessClipExporter(ILoggerFactory loggerFactory, string? ffmpegPathOverride = null)
+    {
+        _logger = loggerFactory.CreateLogger<FfmpegSubprocessClipExporter>();
+        _ffmpegPath = !string.IsNullOrWhiteSpace(ffmpegPathOverride) ? ffmpegPathOverride! : ResolveDefault();
+    }
+
+    public async Task ExportAsync(ClipExportRequest request, IProgress<double>? progress, CancellationToken ct)
+    {
+        var dur = ClipBounds.Duration(request.Start, request.End);
+        if (dur <= TimeSpan.Zero)
+            throw new ArgumentException("Export range is empty", nameof(request));
+
+        Directory.CreateDirectory(Path.GetDirectoryName(request.DestinationPath)!);
+
+        var startSec = request.Start.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
+        var durSec = dur.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture);
+
+        var psi = new ProcessStartInfo(_ffmpegPath)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("-hide_banner");
+        psi.ArgumentList.Add("-y");
+
+        if (request.Precise)
+        {
+            // Output seeking (after -i) = frame-accurate; re-encode video.
+            psi.ArgumentList.Add("-i"); psi.ArgumentList.Add(request.SourcePath);
+            psi.ArgumentList.Add("-ss"); psi.ArgumentList.Add(startSec);
+            psi.ArgumentList.Add("-t"); psi.ArgumentList.Add(durSec);
+            psi.ArgumentList.Add("-c:v"); psi.ArgumentList.Add("libx264");
+            psi.ArgumentList.Add("-preset"); psi.ArgumentList.Add("veryfast");
+            psi.ArgumentList.Add("-crf"); psi.ArgumentList.Add("20");
+            psi.ArgumentList.Add("-c:a"); psi.ArgumentList.Add("copy");
+        }
+        else
+        {
+            // Input seeking (before -i) = fast, snaps to the keyframe ≤ start.
+            psi.ArgumentList.Add("-ss"); psi.ArgumentList.Add(startSec);
+            psi.ArgumentList.Add("-i"); psi.ArgumentList.Add(request.SourcePath);
+            psi.ArgumentList.Add("-t"); psi.ArgumentList.Add(durSec);
+            psi.ArgumentList.Add("-c"); psi.ArgumentList.Add("copy");
+            psi.ArgumentList.Add("-movflags"); psi.ArgumentList.Add("+faststart");
+        }
+        psi.ArgumentList.Add(request.DestinationPath);
+
+        var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to launch ffmpeg (check PATH)");
+
+        var totalSec = dur.TotalSeconds;
+        var stderr = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardError.ReadLineAsync().ConfigureAwait(false)) is not null)
+            {
+                var m = TimeRegex().Match(line);
+                if (m.Success && totalSec > 0)
+                {
+                    var t = int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture) * 3600
+                          + int.Parse(m.Groups[2].Value, CultureInfo.InvariantCulture) * 60
+                          + int.Parse(m.Groups[3].Value, CultureInfo.InvariantCulture)
+                          + double.Parse("0." + m.Groups[4].Value, CultureInfo.InvariantCulture);
+                    progress?.Report(Math.Clamp(t / totalSec, 0, 1));
+                }
+                else
+                {
+                    _logger.LogDebug("ffmpeg-export: {Line}", line);
+                }
+            }
+        }, ct);
+
+        try
+        {
+            await proc.WaitForExitAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            try { proc.Kill(entireProcessTree: true); } catch (Exception ex) { _logger.LogDebug(ex, "Kill on cancel failed"); }
+            throw;
+        }
+
+        await stderr.ConfigureAwait(false);
+
+        if (proc.ExitCode != 0)
+            throw new InvalidOperationException($"ffmpeg export failed (exit {proc.ExitCode})");
+
+        progress?.Report(1.0);
+    }
+
+    private static string ResolveDefault()
+    {
+        var (rid, exe) = RuntimeIds.Current();
+        if (rid is not null)
+        {
+            var bundled = Path.Combine(AppContext.BaseDirectory, "runtimes", rid, "native", exe);
+            if (File.Exists(bundled)) return bundled;
+        }
+        return "ffmpeg";
+    }
+}

--- a/src/OpenIPC.Viewer.Video/Recording/LibavformatClipExporter.cs
+++ b/src/OpenIPC.Viewer.Video/Recording/LibavformatClipExporter.cs
@@ -1,0 +1,164 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using FFmpeg.AutoGen.Abstractions;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.Core.Archive;
+using OpenIPC.Viewer.Video.Pipeline;
+
+namespace OpenIPC.Viewer.Video.Recording;
+
+// In-process clip export via FFmpeg.AutoGen libavformat (Phase 16.5) — the
+// mobile counterpart to FfmpegSubprocessClipExporter, since Android/iOS can't
+// spawn ffmpeg.exe. Stream-copy remux of [Start, End): seek BACKWARD to the
+// keyframe at/before Start (GOP-accurate, same as `ffmpeg -ss … -c copy`),
+// copy packets until End, and let the muxer shift timestamps to zero.
+//
+// Precise (frame-accurate) export needs a decode+re-encode pass and is not
+// implemented in-process yet; the request falls back to the fast stream copy.
+public sealed class LibavformatClipExporter : IClipExporter
+{
+    private readonly ILogger<LibavformatClipExporter> _logger;
+
+    public LibavformatClipExporter(ILoggerFactory loggerFactory)
+        => _logger = loggerFactory.CreateLogger<LibavformatClipExporter>();
+
+    public Task ExportAsync(ClipExportRequest request, IProgress<double>? progress, CancellationToken ct)
+    {
+        var dur = ClipBounds.Duration(request.Start, request.End);
+        if (dur <= TimeSpan.Zero)
+            throw new ArgumentException("Export range is empty", nameof(request));
+
+        if (request.Precise)
+            _logger.LogInformation("Precise export not supported in-process; using stream copy.");
+
+        // libav calls block — run off the caller's thread.
+        return Task.Run(() => Run(request, dur, progress, ct), ct);
+    }
+
+    private unsafe void Run(ClipExportRequest request, TimeSpan dur, IProgress<double>? progress, CancellationToken ct)
+    {
+        FfmpegRuntime.EnsureInitialized();
+        Directory.CreateDirectory(Path.GetDirectoryName(request.DestinationPath)!);
+
+        AVFormatContext* inputCtx = null;
+        AVFormatContext* outputCtx = null;
+        AVPacket* packet = null;
+        var streamMap = Array.Empty<int>();
+
+        try
+        {
+            // --- Input ---
+            var ret = ffmpeg.avformat_open_input(&inputCtx, request.SourcePath, null, null);
+            FfmpegError.ThrowIfError(ret, "avformat_open_input");
+            ret = ffmpeg.avformat_find_stream_info(inputCtx, null);
+            FfmpegError.ThrowIfError(ret, "avformat_find_stream_info");
+
+            // --- Output (plain mp4; moov-at-end is the most compatible) ---
+            AVFormatContext* outRaw = null;
+            ret = ffmpeg.avformat_alloc_output_context2(&outRaw, null, "mp4", request.DestinationPath);
+            FfmpegError.ThrowIfError(ret, "avformat_alloc_output_context2");
+            outputCtx = outRaw;
+
+            streamMap = new int[(int)inputCtx->nb_streams];
+            for (var i = 0; i < (int)inputCtx->nb_streams; i++)
+            {
+                streamMap[i] = -1;
+                var inStream = inputCtx->streams[i];
+                var kind = inStream->codecpar->codec_type;
+                if (kind != AVMediaType.AVMEDIA_TYPE_VIDEO && kind != AVMediaType.AVMEDIA_TYPE_AUDIO)
+                    continue;
+
+                var outStream = ffmpeg.avformat_new_stream(outputCtx, null);
+                if (outStream == null) throw new InvalidOperationException("avformat_new_stream returned null");
+                ret = ffmpeg.avcodec_parameters_copy(outStream->codecpar, inStream->codecpar);
+                FfmpegError.ThrowIfError(ret, "avcodec_parameters_copy");
+                outStream->codecpar->codec_tag = 0;
+                streamMap[i] = (int)outStream->index;
+            }
+
+            if ((outputCtx->oformat->flags & ffmpeg.AVFMT_NOFILE) == 0)
+            {
+                ret = ffmpeg.avio_open(&outputCtx->pb, request.DestinationPath, ffmpeg.AVIO_FLAG_WRITE);
+                FfmpegError.ThrowIfError(ret, "avio_open");
+            }
+
+            // Seek to the keyframe at/before Start (stream_index -1 → AV_TIME_BASE units).
+            var startTs = (long)(request.Start.TotalSeconds * ffmpeg.AV_TIME_BASE);
+            var seekRet = ffmpeg.av_seek_frame(inputCtx, -1, startTs, ffmpeg.AVSEEK_FLAG_BACKWARD);
+            if (seekRet < 0)
+                _logger.LogWarning("Clip seek failed ({Err}); exporting from start.", FfmpegError.Describe(seekRet));
+
+            // Let the muxer rebase the first timestamp to zero so the clip starts
+            // at 0 (mirrors `-avoid_negative_ts make_zero`). 2 = AVFMT_AVOID_NEG_TS_MAKE_ZERO.
+            outputCtx->avoid_negative_ts = 2;
+
+            ret = ffmpeg.avformat_write_header(outputCtx, null);
+            FfmpegError.ThrowIfError(ret, "avformat_write_header");
+
+            var endSec = request.End.TotalSeconds;
+            var startSec = request.Start.TotalSeconds;
+            var durSec = dur.TotalSeconds;
+
+            packet = ffmpeg.av_packet_alloc();
+            while (!ct.IsCancellationRequested)
+            {
+                ret = ffmpeg.av_read_frame(inputCtx, packet);
+                if (ret < 0) break; // EOF or error → done
+
+                var inIdx = packet->stream_index;
+                if (inIdx >= streamMap.Length || streamMap[inIdx] < 0)
+                {
+                    ffmpeg.av_packet_unref(packet);
+                    continue;
+                }
+
+                var inStream = inputCtx->streams[inIdx];
+                var refTs = packet->pts != ffmpeg.AV_NOPTS_VALUE ? packet->pts : packet->dts;
+                if (refTs != ffmpeg.AV_NOPTS_VALUE)
+                {
+                    var ptsSec = refTs * ffmpeg.av_q2d(inStream->time_base);
+                    if (ptsSec > endSec) { ffmpeg.av_packet_unref(packet); break; } // past the out-point
+                    if (durSec > 0)
+                        progress?.Report(Math.Clamp((ptsSec - startSec) / durSec, 0, 1));
+                }
+
+                var outStream = outputCtx->streams[streamMap[inIdx]];
+                packet->stream_index = streamMap[inIdx];
+                ffmpeg.av_packet_rescale_ts(packet, inStream->time_base, outStream->time_base);
+                packet->pos = -1;
+
+                ret = ffmpeg.av_interleaved_write_frame(outputCtx, packet);
+                if (ret < 0)
+                {
+                    _logger.LogWarning("av_interleaved_write_frame failed: {Err}", FfmpegError.Describe(ret));
+                    break;
+                }
+                // av_interleaved_write_frame unrefs the packet internally.
+            }
+
+            ct.ThrowIfCancellationRequested();
+
+            var trailerRet = ffmpeg.av_write_trailer(outputCtx);
+            if (trailerRet < 0)
+                _logger.LogWarning("av_write_trailer failed: {Err}", FfmpegError.Describe(trailerRet));
+
+            progress?.Report(1.0);
+        }
+        finally
+        {
+            if (packet != null) { var p = packet; ffmpeg.av_packet_free(&p); }
+            if (outputCtx != null)
+            {
+                if (outputCtx->pb != null && (outputCtx->oformat->flags & ffmpeg.AVFMT_NOFILE) == 0)
+                {
+                    var pb = outputCtx->pb;
+                    ffmpeg.avio_closep(&pb);
+                }
+                ffmpeg.avformat_free_context(outputCtx);
+            }
+            if (inputCtx != null) ffmpeg.avformat_close_input(&inputCtx);
+        }
+    }
+}

--- a/src/OpenIPC.Viewer.iOS/Composition.cs
+++ b/src/OpenIPC.Viewer.iOS/Composition.cs
@@ -51,6 +51,10 @@ internal static class Composition
         // §10.6). Idle-timer-disabled lifecycle hook is a follow-up.
         services.AddSingleton<IRecorder, LibavformatRecorder>();
 
+        // Clip export (Phase 16.5) — in-process libavformat (no subprocess on iOS).
+        services.AddSingleton<OpenIPC.Viewer.Core.Archive.IClipExporter,
+            OpenIPC.Viewer.Video.Recording.LibavformatClipExporter>();
+
         services.AddSharedServices();
 
         var provider = services.BuildServiceProvider(validateScopes: true);

--- a/tests/OpenIPC.Viewer.Core.Tests/Archive/CalendarActivityTests.cs
+++ b/tests/OpenIPC.Viewer.Core.Tests/Archive/CalendarActivityTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using OpenIPC.Viewer.Core.Archive;
+
+namespace OpenIPC.Viewer.Core.Tests.Archive;
+
+// Per-day aggregation for the archive calendar (Phase 16.3/16.7). UTC zone keeps
+// the local/UTC boundary deterministic across machines.
+public sealed class CalendarActivityTests
+{
+    private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+    private static DateTime U(int y, int m, int d, int h = 12) => new(y, m, d, h, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void ForMonth_CountsRecordingsAndEventsPerDay()
+    {
+        var recordings = new[] { U(2026, 1, 5), U(2026, 1, 5, 14), U(2026, 1, 6) };
+        var events = new[] { U(2026, 1, 5, 9), U(2026, 2, 1) }; // Feb event excluded
+
+        var result = CalendarActivity.ForMonth(2026, 1, recordings, events, Utc);
+
+        var jan5 = result[new DateTime(2026, 1, 5)];
+        Assert.Equal(2, jan5.RecordingCount);
+        Assert.Equal(1, jan5.EventCount);
+        Assert.Equal(3, jan5.Total);
+
+        var jan6 = result[new DateTime(2026, 1, 6)];
+        Assert.Equal(1, jan6.RecordingCount);
+        Assert.Equal(0, jan6.EventCount);
+
+        Assert.False(result.ContainsKey(new DateTime(2026, 2, 1)));
+    }
+
+    [Fact]
+    public void ForMonth_IgnoresOtherMonths()
+    {
+        var recordings = new[] { U(2025, 12, 31), U(2026, 2, 1) };
+        var result = CalendarActivity.ForMonth(2026, 1, recordings, Array.Empty<DateTime>(), Utc);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Intensity_NormalizesAgainstBusiestDay()
+    {
+        var recordings = new[] { U(2026, 1, 5), U(2026, 1, 5), U(2026, 1, 5), U(2026, 1, 6) };
+        var result = CalendarActivity.ForMonth(2026, 1, recordings, Array.Empty<DateTime>(), Utc);
+        var max = result.Values.Max(d => d.Total);
+
+        Assert.Equal(1.0, CalendarActivity.Intensity(result[new DateTime(2026, 1, 5)], max), 3);
+        Assert.Equal(1.0 / 3, CalendarActivity.Intensity(result[new DateTime(2026, 1, 6)], max), 3);
+    }
+}

--- a/tests/OpenIPC.Viewer.Core.Tests/Archive/ClipBoundsTests.cs
+++ b/tests/OpenIPC.Viewer.Core.Tests/Archive/ClipBoundsTests.cs
@@ -1,0 +1,36 @@
+using System;
+using OpenIPC.Viewer.Core.Archive;
+
+namespace OpenIPC.Viewer.Core.Tests.Archive;
+
+// Keyframe-boundary math for stream-copy export (Phase 16.5/16.7).
+public sealed class ClipBoundsTests
+{
+    private static readonly TimeSpan[] Keyframes =
+    {
+        TimeSpan.Zero, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4),
+        TimeSpan.FromSeconds(6), TimeSpan.FromSeconds(8),
+    };
+
+    [Fact]
+    public void SnapStart_PicksLastKeyframeAtOrBefore()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(4), ClipBounds.SnapStartToKeyframe(TimeSpan.FromSeconds(5), Keyframes));
+        Assert.Equal(TimeSpan.FromSeconds(2), ClipBounds.SnapStartToKeyframe(TimeSpan.FromSeconds(2), Keyframes));
+        Assert.Equal(TimeSpan.Zero, ClipBounds.SnapStartToKeyframe(TimeSpan.FromSeconds(1), Keyframes));
+    }
+
+    [Fact]
+    public void SnapStart_BeyondLastKeyframe_ReturnsLast()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(8), ClipBounds.SnapStartToKeyframe(TimeSpan.FromSeconds(20), Keyframes));
+    }
+
+    [Fact]
+    public void Duration_IsZeroWhenEndNotAfterStart()
+    {
+        Assert.Equal(TimeSpan.FromSeconds(3), ClipBounds.Duration(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5)));
+        Assert.Equal(TimeSpan.Zero, ClipBounds.Duration(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(2)));
+        Assert.Equal(TimeSpan.Zero, ClipBounds.Duration(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5)));
+    }
+}

--- a/tests/OpenIPC.Viewer.Core.Tests/Timeline/TimelineTicksTests.cs
+++ b/tests/OpenIPC.Viewer.Core.Tests/Timeline/TimelineTicksTests.cs
@@ -17,9 +17,9 @@ public sealed class TimelineTicksTests
     [Fact]
     public void ZoomedOut_ChoosesCoarseStep()
     {
-        // A full day over 1000px → target 6912s → snaps up to 3h.
+        // A full day over 1000px → target 6912s → smallest nice step ≥ that is 2h.
         var step = TimelineTicks.ChooseStep(visibleSeconds: 86400, width: 1000, minSpacingPx: 80);
-        Assert.Equal(TimeSpan.FromHours(3), step);
+        Assert.Equal(TimeSpan.FromHours(2), step);
     }
 
     [Fact]

--- a/tests/OpenIPC.Viewer.Core.Tests/Timeline/TimelineTicksTests.cs
+++ b/tests/OpenIPC.Viewer.Core.Tests/Timeline/TimelineTicksTests.cs
@@ -1,0 +1,31 @@
+using System;
+using OpenIPC.Viewer.Core.Timeline;
+
+namespace OpenIPC.Viewer.Core.Tests.Timeline;
+
+// Adaptive label step: seconds when zoomed in, hours when zoomed out (16.4).
+public sealed class TimelineTicksTests
+{
+    [Fact]
+    public void ZoomedIn_ChoosesSecondsScaleStep()
+    {
+        // 20s visible over 1000px, ≥80px spacing → ≥1.6s target → 2s step.
+        var step = TimelineTicks.ChooseStep(visibleSeconds: 20, width: 1000, minSpacingPx: 80);
+        Assert.Equal(TimeSpan.FromSeconds(2), step);
+    }
+
+    [Fact]
+    public void ZoomedOut_ChoosesCoarseStep()
+    {
+        // A full day over 1000px → target 6912s → snaps up to 3h.
+        var step = TimelineTicks.ChooseStep(visibleSeconds: 86400, width: 1000, minSpacingPx: 80);
+        Assert.Equal(TimeSpan.FromHours(3), step);
+    }
+
+    [Fact]
+    public void DegenerateWidth_ReturnsMaxStep()
+    {
+        var step = TimelineTicks.ChooseStep(visibleSeconds: 100, width: 0);
+        Assert.Equal(TimeSpan.FromHours(24), step);
+    }
+}

--- a/tests/OpenIPC.Viewer.Core.Tests/Timeline/TimelineViewportTests.cs
+++ b/tests/OpenIPC.Viewer.Core.Tests/Timeline/TimelineViewportTests.cs
@@ -1,0 +1,73 @@
+using System;
+using OpenIPC.Viewer.Core.Timeline;
+
+namespace OpenIPC.Viewer.Core.Tests.Timeline;
+
+// Time↔pixel mapping, cursor-anchored zoom, and clamping (Phase 16.4/16.7).
+public sealed class TimelineViewportTests
+{
+    private static readonly DateTime T0 = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static DateTime At(double sec) => T0.AddSeconds(sec);
+
+    private static TimelineViewport Make() => new(T0, At(100)); // 100s total
+
+    [Fact]
+    public void TimeToX_MapsLinearlyAcrossWidth()
+    {
+        var vp = Make();
+        Assert.Equal(0, vp.TimeToX(At(0), 1000), 3);
+        Assert.Equal(500, vp.TimeToX(At(50), 1000), 3);
+        Assert.Equal(1000, vp.TimeToX(At(100), 1000), 3);
+    }
+
+    [Fact]
+    public void XToTime_RoundTripsTimeToX()
+    {
+        var vp = Make();
+        var t = At(37.5);
+        var x = vp.TimeToX(t, 800);
+        var back = vp.XToTime(x, 800);
+        Assert.Equal(t, back, TimeSpan.FromMilliseconds(1));
+    }
+
+    [Fact]
+    public void ZoomAt_KeepsTimeUnderCursorFixed()
+    {
+        var vp = Make();
+        // Cursor at the middle → 50s. Zoom in 2×.
+        vp.ZoomAt(anchorX: 500, width: 1000, factor: 2);
+        Assert.Equal(50, vp.VisibleSeconds, 3);            // span halved
+        Assert.Equal(500, vp.TimeToX(At(50), 1000), 1);    // anchor stays put
+        Assert.Equal(At(25), vp.VisibleStart, TimeSpan.FromMilliseconds(5));
+        Assert.Equal(At(75), vp.VisibleEnd, TimeSpan.FromMilliseconds(5));
+    }
+
+    [Fact]
+    public void ZoomOut_ClampsToTotalRange()
+    {
+        var vp = Make();
+        vp.ZoomAt(500, 1000, 4);    // zoom in first
+        vp.ZoomAt(500, 1000, 0.01); // huge zoom-out
+        Assert.Equal(100, vp.VisibleSeconds, 3);
+        Assert.Equal(T0, vp.VisibleStart);
+        Assert.Equal(At(100), vp.VisibleEnd);
+    }
+
+    [Fact]
+    public void ZoomIn_ClampsToMinVisibleSeconds()
+    {
+        var vp = Make();
+        vp.ZoomAt(500, 1000, 1_000_000);
+        Assert.Equal(TimelineViewport.MinVisibleSeconds, vp.VisibleSeconds, 3);
+    }
+
+    [Fact]
+    public void Pan_ClampsAtStartEdge()
+    {
+        var vp = Make();
+        vp.ZoomAt(0, 1000, 2);              // 0..50s window anchored at left
+        vp.Pan(deltaX: 500, width: 1000);  // drag right → window earlier, clamps at 0
+        Assert.Equal(T0, vp.VisibleStart);
+        Assert.Equal(50, vp.VisibleSeconds, 3);
+    }
+}

--- a/tests/OpenIPC.Viewer.Video.Tests/ClipExportIntegrationTests.cs
+++ b/tests/OpenIPC.Viewer.Video.Tests/ClipExportIntegrationTests.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenIPC.Viewer.Core.Archive;
+using OpenIPC.Viewer.Core.Entities;
+using OpenIPC.Viewer.Core.Recording;
+using OpenIPC.Viewer.Core.Video;
+using OpenIPC.Viewer.Video.Pipeline;
+using OpenIPC.Viewer.Video.Recording;
+
+namespace OpenIPC.Viewer.Video.Tests;
+
+// Phase 16.7 integration: record a few seconds (in-process libav, the mobile
+// path) → probe the file → export an in/out range → probe the clip. Verifies
+// the probe reports a real duration and the clip length ≈ the selection.
+// Gated on the MediaMTX fixture (skips when docker isn't up), like the live
+// session test. Tolerances are loose — this is an end-to-end smoke test.
+public sealed class ClipExportIntegrationTests
+{
+    [SkippableFact]
+    public async Task Record_Probe_Export_RoundTrip()
+    {
+        Skip.IfNot(MediaMtxFixture.IsReachable(),
+            "MediaMTX not running on localhost:8554 — start tools/mediamtx/docker-compose.yml first.");
+
+        var dir = Path.Combine(Path.GetTempPath(), "openipc-cliptest-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // --- Record ~5s ---
+            var recorder = new LibavformatRecorder(NullLoggerFactory.Instance);
+            var options = new RecordingOptions(
+                CameraId: CameraId.New(),
+                RtspUri: new Uri(MediaMtxFixture.TestStreamUri),
+                Credentials: null,
+                OutputDirectory: dir,
+                FilenamePattern: "rec.mp4",
+                SegmentDuration: TimeSpan.FromMinutes(10));
+
+            var session = await recorder.StartAsync(options, CancellationToken.None);
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            var sourcePath = session.CurrentSegmentPath;
+            await session.StopAsync(CancellationToken.None);
+            await session.DisposeAsync();
+
+            Assert.False(string.IsNullOrEmpty(sourcePath), "Recorder produced no file path");
+            Assert.True(File.Exists(sourcePath), $"Recorded file missing: {sourcePath}");
+
+            // --- Probe the recording ---
+            var probe = new FfmpegMediaProbe(NullLogger<FfmpegMediaProbe>.Instance);
+            var srcInfo = await probe.ProbeAsync(sourcePath!, CancellationToken.None);
+            Assert.InRange(srcInfo.Duration.TotalSeconds, 1.5, 15.0);
+
+            // --- Export [1s, 3s] (stream copy) ---
+            var clipPath = Path.Combine(dir, "clip.mp4");
+            var exporter = new LibavformatClipExporter(NullLoggerFactory.Instance);
+            await exporter.ExportAsync(
+                new ClipExportRequest(sourcePath!, clipPath, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), Precise: false),
+                progress: null, CancellationToken.None);
+
+            Assert.True(File.Exists(clipPath), "Exported clip missing");
+
+            // --- Probe the clip: ~2s ± GOP slack ---
+            var clipInfo = await probe.ProbeAsync(clipPath, CancellationToken.None);
+            Assert.InRange(clipInfo.Duration.TotalSeconds, 0.3, 5.0);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

Turns recordings into a real **archive workflow**. Phase 6 shipped
recording but no playback at all, so this PR first adds the missing recordings
**player** (file decode + seek + duration probe), then the archive-pro layer on
top: a canvas timeline with cursor/pinch zoom and event markers, an activity
calendar, a day event list, and in/out **clip export**. Recording is switched to
fragmented MP4 so files survive a crash. Cross-platform (Win/Lin/Mac/Android/iOS).

## Related

## What's included

- **16.1 Fragmented MP4** — both recorders write `+frag_keyframe+empty_moov+default_base_moof`
  (`FfmpegRecordingSession`, `LibavformatRecordingSession`), so a file is playable
  mid-record and survives a power loss / crash with no "indexing".
- **16.2 Player + fast seek + duration probe** — `IPlaybackSession`/`FfmpegPlaybackSession`
  (software decode, PTS-paced, keyframe seek), `IMediaProbe`/`FfmpegMediaProbe` for an
  exact duration before the first frame. New `RecordingPlayerPage` (transport bar +
  seek), opened from a recording row.
- **16.3 Activity calendar** — `CalendarActivity` aggregates recordings + events per
  local day (DST-aware), intensity-shaded month grid; clicking a day filters the
  recordings list. Per-month aggregates are cached.
- **16.4 Canvas timeline** — `TimelineControl` (DrawingContext, markers bucketed per
  pixel column), cursor-anchored **wheel + pinch** zoom, drag-pan, click/marker → seek;
  adaptive time labels (hours → minutes → seconds). Motion + AI-detection markers.
- **16.5 Clip export (in/out)** — mark start/end on the timeline, export MP4 via
  stream-copy (`-c copy`, GOP-accurate) with an optional precise re-encode.
- **16.6 Day event list** — side panel of the day's motion/detection events with a
  type filter (All / Motion / AI), click = seek.

## Cross-platform / mobile parity

- Recording, playback, seek and probe run through FFmpeg.AutoGen (software) on all
  heads — same stack as live decode.
- **Clip export is split per head like `IRecorder`**: ffmpeg subprocess on desktop,
  in-process **`LibavformatClipExporter`** on Android/iOS (the sandbox can't exec a
  binary). On mobile the exported clip is handed to the native share sheet.
- Timeline zoom works on touch via pinch (wheel has no touch equivalent).

## Tests

- Unit: `TimelineViewport` (time↔pixel, cursor-anchored zoom, clamping), `TimelineTicks`
  (adaptive labels), `CalendarActivity` (per-day aggregation, intensity), `ClipBounds`
  (keyframe snap, duration).
- Integration (`SkippableFact`, gated on the MediaMTX fixture): record → probe → export
  → probe; asserts a real probed duration and clip length ≈ the selection.
- Solution builds with **0 warnings** across all five heads.

## How to try

1. Record a camera (Live → REC), then open **Recordings**.
2. The calendar highlights days with activity; click a day to filter.
3. Open a recording → scrub/zoom the timeline, click a marker to jump to an event.
4. Mark in/out → **Export** → pick a file (desktop) or share the clip (mobile).

## Known limitations / deferred

- Precise (frame-accurate) export on the in-process path falls back to stream-copy
  (no in-process re-encode yet).
- H.265 smooth-seek remux not implemented (deferred; only if stalling is reported).
- `LibavformatRecordingSession` has no segment rotation (single file per session) —
  limits practical Android recording length; a follow-up.
- Phone layout of the archive/player not yet device-verified.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
