### PR TITLE
fix(recording): recorded files now appear in Recordings list

### DIFF
--- a/src/OpenIPC.Viewer.Video/OpenIPC.Viewer.Video.csproj
+++ b/src/OpenIPC.Viewer.Video/OpenIPC.Viewer.Video.csproj
@@ -42,6 +42,16 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <Visible>false</Visible>
     </Content>
+    <!-- ffmpeg.exe: the subprocess recorder + clip-exporter need it (segment
+         rotation, precise re-encode). Without it, recording/export fail on
+         packaged Windows builds. Tiny shared-build exe; uses the DLLs above. -->
+    <Content Include="..\..\runtimes\win-x64\native\ffmpeg.exe"
+             Condition="Exists('..\..\runtimes\win-x64\native\ffmpeg.exe')">
+      <Link>runtimes\win-x64\native\ffmpeg.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <Visible>false</Visible>
+    </Content>
     <Content Include="..\..\runtimes\linux-x64\native\*.so*"
              Condition="Exists('..\..\runtimes\linux-x64\native')">
       <Link>runtimes\linux-x64\native\%(Filename)%(Extension)</Link>

--- a/src/OpenIPC.Viewer.Video/Recording/FfmpegRecordingSession.cs
+++ b/src/OpenIPC.Viewer.Video/Recording/FfmpegRecordingSession.cs
@@ -56,7 +56,11 @@ internal sealed partial class FfmpegRecordingSession : IRecordingSession
             CreateNoWindow = true,
         };
         psi.ArgumentList.Add("-hide_banner");
-        psi.ArgumentList.Add("-loglevel"); psi.ArgumentList.Add("warning");
+        // verbose (not warning): the segment muxer logs "Opening '<path>' for
+        // writing" at AV_LOG_VERBOSE. We parse that line to learn each segment
+        // path and fire Started/SegmentRotated — at warning it's suppressed, so
+        // no DB row is written and the recording never shows in the list.
+        psi.ArgumentList.Add("-loglevel"); psi.ArgumentList.Add("verbose");
         psi.ArgumentList.Add("-rtsp_transport"); psi.ArgumentList.Add("tcp");
         psi.ArgumentList.Add("-i"); psi.ArgumentList.Add(BuildRtspUri(_options.RtspUri, _options.Credentials).ToString());
         psi.ArgumentList.Add("-c"); psi.ArgumentList.Add("copy");

--- a/tools/fetch-ffmpeg.ps1
+++ b/tools/fetch-ffmpeg.ps1
@@ -1,7 +1,8 @@
 <#
 .SYNOPSIS
-  Downloads FFmpeg shared-build DLLs (LGPL) for Windows x64 and places them in
-  runtimes/win-x64/native/. The DLLs are git-ignored — every dev runs this once.
+  Downloads the FFmpeg shared build (LGPL) for Windows x64 and places its DLLs
+  + ffmpeg.exe in runtimes/win-x64/native/. ffmpeg.exe is what the recorder and
+  clip-exporter shell out to. Everything is git-ignored — every dev runs this once.
 
 .NOTES
   Source: BtbN/FFmpeg-Builds GitHub releases (https://github.com/BtbN/FFmpeg-Builds).
@@ -70,4 +71,15 @@ foreach ($pattern in $requiredDlls) {
         }
 }
 
-Write-Host "[fetch-ffmpeg] done. $nativeDir contains $((Get-ChildItem $nativeDir -Filter '*.dll').Count) DLL(s)."
+# ffmpeg.exe — the recorder and clip-exporter shell out to it (segment rotation,
+# precise re-encode). The shared-build exe is tiny; it loads the DLLs above.
+# Without it, recording/export fail with "cannot find ffmpeg" on packaged builds.
+$ffmpegExe = Join-Path $srcBin.FullName "ffmpeg.exe"
+if (Test-Path $ffmpegExe) {
+    Copy-Item -Path $ffmpegExe -Destination $nativeDir -Force
+    Write-Host "  ffmpeg.exe"
+} else {
+    Write-Warning "[fetch-ffmpeg] ffmpeg.exe not found in $($srcBin.FullName) — recording/export will fall back to PATH."
+}
+
+Write-Host "[fetch-ffmpeg] done. $nativeDir contains $((Get-ChildItem $nativeDir -Filter '*.dll').Count) DLL(s) + ffmpeg.exe."


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- FfmpegRecordingSession parses ffmpeg's "Opening '<path>' for writing" line to
  fire Started/SegmentRotated, which is what writes the Recordings DB row
- that line is logged at AV_LOG_VERBOSE, but ffmpeg ran at -loglevel warning, so
  it was suppressed → no Started event → no DB row (file on disk, list empty)
- bump to -loglevel verbose so segment opens are captured

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
