### PR TITLE
fix(ui): reflow pages for narrow/mobile viewports

### DIFF
--- a/src/OpenIPC.Viewer.App/Behaviors/Adaptive.cs
+++ b/src/OpenIPC.Viewer.App/Behaviors/Adaptive.cs
@@ -1,0 +1,70 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace OpenIPC.Viewer.App.Behaviors;
+
+/// <summary>
+/// Attached behaviour that toggles the <c>compact</c> style class on a control
+/// when its own measured width drops below <see cref="CompactBelowProperty"/>.
+///
+/// Lets a page reflow for phone-width viewports straight from XAML style
+/// selectors (e.g. <c>Selector="DockPanel.compact &gt; ...."</c>) without
+/// hand-written per-page <c>SizeChanged</c> code-behind. It mirrors the 700px
+/// desktop/mobile breakpoint in <see cref="Views.MainView"/>, but scoped to an
+/// individual control rather than the whole window — useful because a panel's
+/// own width (after sidebar + padding) is what actually decides whether its
+/// children fit, not the raw window width.
+/// </summary>
+public static class Adaptive
+{
+    public static readonly AttachedProperty<double> CompactBelowProperty =
+        AvaloniaProperty.RegisterAttached<Control, double>(
+            "CompactBelow", typeof(Adaptive), double.NaN);
+
+    public static void SetCompactBelow(Control control, double value) =>
+        control.SetValue(CompactBelowProperty, value);
+
+    public static double GetCompactBelow(Control control) =>
+        control.GetValue(CompactBelowProperty);
+
+    static Adaptive()
+    {
+        CompactBelowProperty.Changed.AddClassHandler<Control>(OnCompactBelowChanged);
+    }
+
+    private static void OnCompactBelowChanged(Control control, AvaloniaPropertyChangedEventArgs e)
+    {
+        // Idempotent — detach first so re-setting the threshold doesn't stack
+        // handlers.
+        control.SizeChanged -= OnSizeChanged;
+        if (!double.IsNaN(GetCompactBelow(control)))
+        {
+            control.SizeChanged += OnSizeChanged;
+            Apply(control, control.Bounds.Width);
+        }
+    }
+
+    private static void OnSizeChanged(object? sender, SizeChangedEventArgs e)
+    {
+        if (sender is Control control)
+            Apply(control, e.NewSize.Width);
+    }
+
+    private static void Apply(Control control, double width)
+    {
+        var threshold = GetCompactBelow(control);
+        if (double.IsNaN(threshold))
+            return;
+
+        // Width is 0 until the first layout pass — treat "unknown" as wide so a
+        // page doesn't flash its compact form before it has been measured.
+        var compact = width > 0 && width < threshold;
+        if (compact == control.Classes.Contains("compact"))
+            return;
+
+        if (compact)
+            control.Classes.Add("compact");
+        else
+            control.Classes.Remove("compact");
+    }
+}

--- a/src/OpenIPC.Viewer.App/Views/Pages/EventsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/EventsPage.axaml
@@ -7,28 +7,27 @@
 
   <Grid RowDefinitions="Auto,*">
 
-    <!-- Header -->
-    <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" Margin="0,0,0,16">
-      <TextBlock Grid.Column="0"
-                 Text="{Binding Title}"
+    <!-- Header: title on top, filter + action wrap below so they never collide
+         with the title on a phone-width viewport. -->
+    <StackPanel Grid.Row="0" Spacing="12" Margin="0,0,0,16">
+      <TextBlock Text="{Binding Title}"
                  FontSize="{StaticResource FontSizeXl}"
                  FontWeight="SemiBold"
-                 Foreground="{StaticResource TextPrimaryBrush}"
-                 VerticalAlignment="Center" />
-      <ComboBox Grid.Column="1"
-                ItemsSource="{Binding CameraOptions}"
-                SelectedItem="{Binding SelectedCamera, Mode=TwoWay}"
-                MinWidth="160" Margin="0,0,8,0" />
-      <Button Grid.Column="2"
-              Content="{Binding [Events.Button.SimulateMotion], Source={x:Static svc:Localizer.Instance}}"
-              Command="{Binding SimulateMotionCommand}"
-              Padding="12,6"
-              Background="Transparent"
-              BorderBrush="{StaticResource BorderMediumBrush}"
-              BorderThickness="1"
-              CornerRadius="6"
-              Foreground="{StaticResource TextPrimaryBrush}" />
-    </Grid>
+                 Foreground="{StaticResource TextPrimaryBrush}" />
+      <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
+        <ComboBox ItemsSource="{Binding CameraOptions}"
+                  SelectedItem="{Binding SelectedCamera, Mode=TwoWay}"
+                  MinWidth="160" />
+        <Button Content="{Binding [Events.Button.SimulateMotion], Source={x:Static svc:Localizer.Instance}}"
+                Command="{Binding SimulateMotionCommand}"
+                Padding="12,6"
+                Background="Transparent"
+                BorderBrush="{StaticResource BorderMediumBrush}"
+                BorderThickness="1"
+                CornerRadius="6"
+                Foreground="{StaticResource TextPrimaryBrush}" />
+      </WrapPanel>
+    </StackPanel>
 
     <!-- Empty -->
     <TextBlock Grid.Row="1"
@@ -53,49 +52,43 @@
                     BorderThickness="1"
                     CornerRadius="6"
                     Padding="12,8">
-              <Grid ColumnDefinitions="120,*,Auto,Auto,Auto">
+              <!-- Kind + camera on top; source / duration / timestamp wrap below
+                   so the row never clips its trailing columns on a phone. -->
+              <StackPanel Spacing="6">
+                <StackPanel Orientation="Horizontal" Spacing="12" VerticalAlignment="Center">
+                  <Border Background="{StaticResource WarningBrush}"
+                          CornerRadius="3"
+                          Padding="6,2"
+                          VerticalAlignment="Center">
+                    <TextBlock Text="{Binding KindLabel}"
+                               FontFamily="{StaticResource FontMono}"
+                               FontSize="10"
+                               Foreground="White" />
+                  </Border>
+                  <TextBlock Text="{Binding CameraName}"
+                             Foreground="{StaticResource TextPrimaryBrush}"
+                             VerticalAlignment="Center" />
+                </StackPanel>
 
-                <Border Grid.Column="0"
-                        Background="{StaticResource WarningBrush}"
-                        CornerRadius="3"
-                        Padding="6,2"
-                        HorizontalAlignment="Left">
-                  <TextBlock Text="{Binding KindLabel}"
+                <WrapPanel Orientation="Horizontal" ItemSpacing="16" LineSpacing="4">
+                  <TextBlock Text="{Binding Source}"
                              FontFamily="{StaticResource FontMono}"
-                             FontSize="10"
-                             Foreground="White" />
-                </Border>
-
-                <TextBlock Grid.Column="1"
-                           Text="{Binding CameraName}"
-                           Foreground="{StaticResource TextPrimaryBrush}"
-                           VerticalAlignment="Center"
-                           Margin="12,0,0,0" />
-
-                <TextBlock Grid.Column="2"
-                           Text="{Binding Source}"
-                           FontFamily="{StaticResource FontMono}"
-                           FontSize="11"
-                           Foreground="{StaticResource TextTertiaryBrush}"
-                           VerticalAlignment="Center"
-                           Margin="0,0,16,0" />
-
-                <TextBlock Grid.Column="3"
-                           Text="{Binding Duration}"
-                           FontFamily="{StaticResource FontMono}"
-                           FontSize="11"
-                           Foreground="{StaticResource TextSecondaryBrush}"
-                           VerticalAlignment="Center"
-                           Margin="0,0,16,0"
-                           MinWidth="40" />
-
-                <TextBlock Grid.Column="4"
-                           Text="{Binding OccurredAtLocal, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"
-                           FontFamily="{StaticResource FontMono}"
-                           FontSize="11"
-                           Foreground="{StaticResource TextSecondaryBrush}"
-                           VerticalAlignment="Center" />
-              </Grid>
+                             FontSize="11"
+                             Foreground="{StaticResource TextTertiaryBrush}"
+                             VerticalAlignment="Center" />
+                  <TextBlock Text="{Binding Duration}"
+                             FontFamily="{StaticResource FontMono}"
+                             FontSize="11"
+                             Foreground="{StaticResource TextSecondaryBrush}"
+                             VerticalAlignment="Center"
+                             MinWidth="40" />
+                  <TextBlock Text="{Binding OccurredAtLocal, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"
+                             FontFamily="{StaticResource FontMono}"
+                             FontSize="11"
+                             Foreground="{StaticResource TextSecondaryBrush}"
+                             VerticalAlignment="Center" />
+                </WrapPanel>
+              </StackPanel>
             </Border>
           </DataTemplate>
         </ItemsControl.ItemTemplate>

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingPlayerPage.axaml
@@ -3,10 +3,17 @@
              xmlns:vm="using:OpenIPC.Viewer.App.ViewModels"
              xmlns:controls="using:OpenIPC.Viewer.App.Controls"
              xmlns:svc="using:OpenIPC.Viewer.App.Services"
+             xmlns:b="using:OpenIPC.Viewer.App.Behaviors"
              x:Class="OpenIPC.Viewer.App.Views.Pages.RecordingPlayerPage"
              x:DataType="vm:RecordingPlayerPageViewModel">
 
   <UserControl.Styles>
+    <!-- Narrow viewport: drop the day-event sidebar so the video keeps the full
+         width instead of being squeezed beside a fixed 260px panel. Events
+         remain reachable via the timeline markers below. -->
+    <Style Selector="Grid.compact &gt; Border.eventsidebar">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
     <Style Selector="Button.evfilter">
       <Setter Property="Padding" Value="8,3" />
       <Setter Property="CornerRadius" Value="4" />
@@ -60,7 +67,7 @@
     </Grid>
 
     <!-- Video surface + overlays (left) + day event list (right) -->
-    <Grid Grid.Row="1" ColumnDefinitions="*,Auto">
+    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" b:Adaptive.CompactBelow="620">
       <Grid Grid.Column="0" ClipToBounds="True" Background="Black">
       <controls:RtspVideoView Session="{Binding VideoSession}" />
 
@@ -93,7 +100,7 @@
 
       <!-- Day event list (16.6): motion/detection of this recording's window;
            click an entry to seek; filter by type. -->
-      <Border Grid.Column="1" Width="260" Margin="12,0,0,0"
+      <Border Grid.Column="1" Classes="eventsidebar" Width="260" Margin="12,0,0,0"
               Background="{StaticResource Bg1Brush}"
               BorderBrush="{StaticResource BorderWeakBrush}"
               BorderThickness="1"
@@ -199,29 +206,27 @@
         </Button>
       </Grid>
 
-      <!-- Export bar (16.5): mark in/out, choose precise vs fast copy, export -->
-      <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto" >
-        <Button Grid.Column="0"
-                Command="{Binding SetInCommand}"
+      <!-- Export bar (16.5): mark in/out, choose precise vs fast copy, export.
+           WrapPanel so the cluster reflows on a narrow viewport. -->
+      <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
+        <Button Command="{Binding SetInCommand}"
                 Content="{Binding [Recordings.MarkIn], Source={x:Static svc:Localizer.Instance}}"
                 Background="Transparent" BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
-                CornerRadius="6" Padding="10,5" FontSize="11" Margin="0,0,6,0"
+                CornerRadius="6" Padding="10,5" FontSize="11"
                 Foreground="{StaticResource TextPrimaryBrush}" />
-        <Button Grid.Column="1"
-                Command="{Binding SetOutCommand}"
+        <Button Command="{Binding SetOutCommand}"
                 Content="{Binding [Recordings.MarkOut], Source={x:Static svc:Localizer.Instance}}"
                 Background="Transparent" BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
-                CornerRadius="6" Padding="10,5" FontSize="11" Margin="0,0,6,0"
+                CornerRadius="6" Padding="10,5" FontSize="11"
                 Foreground="{StaticResource TextPrimaryBrush}" />
-        <Button Grid.Column="2"
-                Command="{Binding ClearSelectionCommand}"
+        <Button Command="{Binding ClearSelectionCommand}"
                 IsVisible="{Binding HasSelection}"
                 Content="{Binding [Common.Close], Source={x:Static svc:Localizer.Instance}}"
                 Background="Transparent" BorderThickness="0"
                 CornerRadius="6" Padding="8,5" FontSize="11"
                 Foreground="{StaticResource TextSecondaryBrush}" />
 
-        <StackPanel Grid.Column="3" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center" Margin="12,0">
+        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
           <TextBlock Text="{Binding SelectionLabel}"
                      FontFamily="{StaticResource FontMono}" FontSize="11"
                      Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" />
@@ -232,17 +237,15 @@
                      FontSize="11" Foreground="{StaticResource TextSecondaryBrush}" VerticalAlignment="Center" />
         </StackPanel>
 
-        <CheckBox Grid.Column="4"
-                  IsChecked="{Binding PreciseExport, Mode=TwoWay}"
+        <CheckBox IsChecked="{Binding PreciseExport, Mode=TwoWay}"
                   Content="{Binding [Recordings.Precise], Source={x:Static svc:Localizer.Instance}}"
-                  FontSize="11" VerticalAlignment="Center" Margin="0,0,8,0"
+                  FontSize="11" VerticalAlignment="Center"
                   Foreground="{StaticResource TextSecondaryBrush}" />
-        <Button Grid.Column="5"
-                Command="{Binding ExportCommand}"
+        <Button Command="{Binding ExportCommand}"
                 Content="{Binding [Recordings.Export], Source={x:Static svc:Localizer.Instance}}"
                 Background="{StaticResource AccentBrush}" Foreground="White"
                 CornerRadius="6" Padding="14,5" FontSize="11" />
-      </Grid>
+      </WrapPanel>
     </StackPanel>
 
   </Grid>

--- a/src/OpenIPC.Viewer.App/Views/Pages/RecordingsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/RecordingsPage.axaml
@@ -3,6 +3,7 @@
              xmlns:vm="using:OpenIPC.Viewer.App.ViewModels"
              xmlns:svc="using:OpenIPC.Viewer.App.Services"
              xmlns:pages="using:OpenIPC.Viewer.App.Views.Pages"
+             xmlns:b="using:OpenIPC.Viewer.App.Behaviors"
              x:Class="OpenIPC.Viewer.App.Views.Pages.RecordingsPage"
              x:DataType="vm:RecordingsPageViewModel">
 
@@ -21,19 +22,24 @@
       <Setter Property="BorderBrush" Value="{StaticResource AccentBrush}" />
       <Setter Property="Foreground" Value="White" />
     </Style>
+    <!-- Narrow viewport: the activity calendar drops from the left column to a
+         band above the list so the list keeps the full width instead of being
+         crushed into ~80px next to a fixed 240px calendar. -->
+    <Style Selector="DockPanel.compact &gt; pages|ArchiveCalendarView">
+      <Setter Property="(DockPanel.Dock)" Value="Top" />
+    </Style>
   </UserControl.Styles>
 
   <Grid RowDefinitions="Auto,*">
 
-    <!-- Header: title + segmented Recordings / Snapshots switch -->
-    <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="0,0,0,20">
-      <TextBlock Grid.Column="0"
-                 Text="{Binding Title}"
+    <!-- Header: title on top, the Recordings/Snapshots switch wraps below so a
+         phone-width viewport never shoves the toggle off-screen. -->
+    <StackPanel Grid.Row="0" Spacing="12" Margin="0,0,0,20">
+      <TextBlock Text="{Binding Title}"
                  FontSize="{StaticResource FontSizeXl}"
                  FontWeight="SemiBold"
-                 Foreground="{StaticResource TextPrimaryBrush}"
-                 VerticalAlignment="Center" />
-      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6">
+                 Foreground="{StaticResource TextPrimaryBrush}" />
+      <StackPanel Orientation="Horizontal" Spacing="6">
         <Button Classes="seg" Classes.active="{Binding IsRecordingsTabActive}"
                 Command="{Binding SelectRecordingsCommand}"
                 Content="{Binding [Nav.Recordings], Source={x:Static svc:Localizer.Instance}}" />
@@ -41,144 +47,144 @@
                 Command="{Binding SelectSnapshotsCommand}"
                 Content="{Binding [Snapshots.Title], Source={x:Static svc:Localizer.Instance}}" />
       </StackPanel>
-    </Grid>
+    </StackPanel>
 
     <!-- Snapshots tab -->
     <ContentControl Grid.Row="1" IsVisible="{Binding ShowSnapshots}">
       <pages:SnapshotBrowserView DataContext="{Binding Snapshots}" />
     </ContentControl>
 
-    <!-- Recordings tab: calendar (left) + list (right) -->
-    <Grid Grid.Row="1" IsVisible="{Binding ShowRecordings}" ColumnDefinitions="Auto,*">
+    <!-- Recordings tab: calendar + list. DockPanel docks the calendar Left on a
+         wide viewport and Top when narrow (see the .compact style above), so the
+         list always keeps usable width. -->
+    <DockPanel Grid.Row="1" IsVisible="{Binding ShowRecordings}"
+               b:Adaptive.CompactBelow="620" LastChildFill="True">
 
-      <!-- Activity calendar -->
-      <pages:ArchiveCalendarView Grid.Column="0"
-                                 DataContext="{Binding Calendar}"
-                                 Margin="0,0,16,0"
+      <!-- Activity calendar. Default Dock is Left; trailing margin works for
+           both orientations. -->
+      <pages:ArchiveCalendarView DataContext="{Binding Calendar}"
+                                 Margin="0,0,16,16"
                                  VerticalAlignment="Top" />
 
-      <!-- Empty state -->
-      <TextBlock Grid.Column="1"
-                 IsVisible="{Binding IsEmpty}"
-                 Text="{Binding [Recordings.Empty], Source={x:Static svc:Localizer.Instance}}"
-                 Foreground="{StaticResource TextSecondaryBrush}"
-                 HorizontalAlignment="Center"
-                 VerticalAlignment="Center" />
+      <!-- Remaining area: list + empty/error/loading overlays stacked. -->
+      <Panel>
 
-      <!-- List -->
-      <ScrollViewer Grid.Column="1" IsVisible="{Binding !IsEmpty}">
-        <ItemsControl ItemsSource="{Binding Items}">
-          <ItemsControl.ItemsPanel>
-            <ItemsPanelTemplate>
-              <StackPanel Spacing="8" />
-            </ItemsPanelTemplate>
-          </ItemsControl.ItemsPanel>
-          <ItemsControl.ItemTemplate>
-            <DataTemplate DataType="vm:RecordingRowViewModel">
-              <Border Background="{StaticResource Bg2Brush}"
-                      BorderBrush="{StaticResource BorderWeakBrush}"
-                      BorderThickness="1"
-                      CornerRadius="8"
-                      Padding="14,10">
-                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto,Auto">
-                  <StackPanel Grid.Column="0" Spacing="2">
-                    <TextBlock Text="{Binding FileName}"
-                               FontFamily="{StaticResource FontMono}"
-                               FontSize="{StaticResource FontSizeBase}"
-                               Foreground="{StaticResource TextPrimaryBrush}" />
-                    <TextBlock Text="{Binding CameraName}"
-                               FontSize="{StaticResource FontSizeSm}"
-                               Foreground="{StaticResource TextSecondaryBrush}" />
-                  </StackPanel>
-
-                  <TextBlock Grid.Column="1"
-                             Text="{Binding StartedAtLocal, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"
-                             FontFamily="{StaticResource FontMono}"
-                             FontSize="{StaticResource FontSizeSm}"
-                             Foreground="{StaticResource TextSecondaryBrush}"
-                             VerticalAlignment="Center"
-                             Margin="16,0,16,0" />
-
-                  <TextBlock Grid.Column="2"
-                             Text="{Binding Duration}"
-                             FontFamily="{StaticResource FontMono}"
-                             FontSize="{StaticResource FontSizeSm}"
-                             Foreground="{StaticResource TextSecondaryBrush}"
-                             VerticalAlignment="Center"
-                             Margin="0,0,16,0" />
-
-                  <TextBlock Grid.Column="3"
-                             Text="{Binding SizeLabel}"
-                             FontFamily="{StaticResource FontMono}"
-                             FontSize="{StaticResource FontSizeSm}"
-                             Foreground="{StaticResource TextSecondaryBrush}"
-                             VerticalAlignment="Center"
-                             Margin="0,0,16,0"
-                             MinWidth="70" />
-
-                  <Button Grid.Column="4"
-                          Padding="10,5"
-                          Background="{StaticResource AccentBrush}"
-                          CornerRadius="4"
-                          Margin="0,0,8,0"
-                          VerticalAlignment="Center"
-                          Command="{Binding $parent[ItemsControl].((vm:RecordingsPageViewModel)DataContext).PlayCommand}"
-                          CommandParameter="{Binding}">
-                    <Path Classes="lucide" Data="{StaticResource IconPlay}" Stroke="White" Width="13" Height="13" />
-                  </Button>
-
-                  <Button Grid.Column="5"
-                          Content="{Binding [Common.Delete], Source={x:Static svc:Localizer.Instance}}"
-                          Padding="10,4"
-                          FontSize="11"
-                          Background="Transparent"
-                          BorderBrush="{StaticResource BorderMediumBrush}"
-                          BorderThickness="1"
-                          CornerRadius="4"
-                          Foreground="{StaticResource DangerBrush}"
-                          Command="{Binding $parent[ItemsControl].((vm:RecordingsPageViewModel)DataContext).DeleteCommand}"
-                          CommandParameter="{Binding}" />
-                </Grid>
-              </Border>
-            </DataTemplate>
-          </ItemsControl.ItemTemplate>
-        </ItemsControl>
-      </ScrollViewer>
-
-      <!-- Error overlay -->
-      <StackPanel Grid.Column="1"
-                  IsVisible="{Binding HasLoadError}"
-                  VerticalAlignment="Center"
-                  HorizontalAlignment="Center"
-                  Spacing="12">
-        <TextBlock Text="{Binding LoadError}"
-                   FontSize="{StaticResource FontSizeLg}"
-                   Foreground="{StaticResource DangerBrush}"
-                   HorizontalAlignment="Center" />
-        <Button Content="{Binding [Common.Retry], Source={x:Static svc:Localizer.Instance}}"
-                Command="{Binding ReloadCommand}"
-                Padding="14,8"
-                Background="Transparent"
-                BorderBrush="{StaticResource BorderMediumBrush}"
-                BorderThickness="1"
-                CornerRadius="8"
-                Foreground="{StaticResource TextPrimaryBrush}"
-                HorizontalAlignment="Center" />
-      </StackPanel>
-
-      <!-- Loading overlay (rendered last → on top). -->
-      <StackPanel Grid.Column="1"
-                  IsVisible="{Binding IsLoading}"
-                  VerticalAlignment="Center"
-                  HorizontalAlignment="Center"
-                  Spacing="12">
-        <ProgressBar IsIndeterminate="True" Width="160" />
-        <TextBlock Text="{Binding [Common.Loading], Source={x:Static svc:Localizer.Instance}}"
+        <!-- Empty state -->
+        <TextBlock IsVisible="{Binding IsEmpty}"
+                   Text="{Binding [Recordings.Empty], Source={x:Static svc:Localizer.Instance}}"
                    Foreground="{StaticResource TextSecondaryBrush}"
-                   HorizontalAlignment="Center" />
-      </StackPanel>
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center" />
 
-    </Grid>
+        <!-- List -->
+        <ScrollViewer IsVisible="{Binding !IsEmpty}">
+          <ItemsControl ItemsSource="{Binding Items}">
+            <ItemsControl.ItemsPanel>
+              <ItemsPanelTemplate>
+                <StackPanel Spacing="8" />
+              </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+              <DataTemplate DataType="vm:RecordingRowViewModel">
+                <!-- Two-line card: identity on top, metadata + actions wrap
+                     below so the row never overflows on a phone. -->
+                <Border Background="{StaticResource Bg2Brush}"
+                        BorderBrush="{StaticResource BorderWeakBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        Padding="14,10">
+                  <StackPanel Spacing="8">
+                    <StackPanel Spacing="2">
+                      <TextBlock Text="{Binding FileName}"
+                                 FontFamily="{StaticResource FontMono}"
+                                 FontSize="{StaticResource FontSizeBase}"
+                                 Foreground="{StaticResource TextPrimaryBrush}"
+                                 TextTrimming="CharacterEllipsis" />
+                      <TextBlock Text="{Binding CameraName}"
+                                 FontSize="{StaticResource FontSizeSm}"
+                                 Foreground="{StaticResource TextSecondaryBrush}" />
+                    </StackPanel>
+
+                    <WrapPanel Orientation="Horizontal" ItemSpacing="14" LineSpacing="8">
+                      <TextBlock Text="{Binding StartedAtLocal, StringFormat='{}{0:yyyy-MM-dd HH:mm:ss}'}"
+                                 FontFamily="{StaticResource FontMono}"
+                                 FontSize="{StaticResource FontSizeSm}"
+                                 Foreground="{StaticResource TextSecondaryBrush}"
+                                 VerticalAlignment="Center" />
+                      <TextBlock Text="{Binding Duration}"
+                                 FontFamily="{StaticResource FontMono}"
+                                 FontSize="{StaticResource FontSizeSm}"
+                                 Foreground="{StaticResource TextSecondaryBrush}"
+                                 VerticalAlignment="Center" />
+                      <TextBlock Text="{Binding SizeLabel}"
+                                 FontFamily="{StaticResource FontMono}"
+                                 FontSize="{StaticResource FontSizeSm}"
+                                 Foreground="{StaticResource TextSecondaryBrush}"
+                                 VerticalAlignment="Center"
+                                 MinWidth="70" />
+
+                      <Button Padding="12,5"
+                              Background="{StaticResource AccentBrush}"
+                              CornerRadius="4"
+                              VerticalAlignment="Center"
+                              Command="{Binding $parent[ItemsControl].((vm:RecordingsPageViewModel)DataContext).PlayCommand}"
+                              CommandParameter="{Binding}">
+                        <Path Classes="lucide" Data="{StaticResource IconPlay}" Stroke="White" Width="13" Height="13" />
+                      </Button>
+
+                      <Button Content="{Binding [Common.Delete], Source={x:Static svc:Localizer.Instance}}"
+                              Padding="10,4"
+                              FontSize="11"
+                              VerticalAlignment="Center"
+                              Background="Transparent"
+                              BorderBrush="{StaticResource BorderMediumBrush}"
+                              BorderThickness="1"
+                              CornerRadius="4"
+                              Foreground="{StaticResource DangerBrush}"
+                              Command="{Binding $parent[ItemsControl].((vm:RecordingsPageViewModel)DataContext).DeleteCommand}"
+                              CommandParameter="{Binding}" />
+                    </WrapPanel>
+                  </StackPanel>
+                </Border>
+              </DataTemplate>
+            </ItemsControl.ItemTemplate>
+          </ItemsControl>
+        </ScrollViewer>
+
+        <!-- Error overlay -->
+        <StackPanel IsVisible="{Binding HasLoadError}"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Spacing="12">
+          <TextBlock Text="{Binding LoadError}"
+                     FontSize="{StaticResource FontSizeLg}"
+                     Foreground="{StaticResource DangerBrush}"
+                     HorizontalAlignment="Center" />
+          <Button Content="{Binding [Common.Retry], Source={x:Static svc:Localizer.Instance}}"
+                  Command="{Binding ReloadCommand}"
+                  Padding="14,8"
+                  Background="Transparent"
+                  BorderBrush="{StaticResource BorderMediumBrush}"
+                  BorderThickness="1"
+                  CornerRadius="8"
+                  Foreground="{StaticResource TextPrimaryBrush}"
+                  HorizontalAlignment="Center" />
+        </StackPanel>
+
+        <!-- Loading overlay (rendered last → on top). -->
+        <StackPanel IsVisible="{Binding IsLoading}"
+                    VerticalAlignment="Center"
+                    HorizontalAlignment="Center"
+                    Spacing="12">
+          <ProgressBar IsIndeterminate="True" Width="160" />
+          <TextBlock Text="{Binding [Common.Loading], Source={x:Static svc:Localizer.Instance}}"
+                     Foreground="{StaticResource TextSecondaryBrush}"
+                     HorizontalAlignment="Center" />
+        </StackPanel>
+
+      </Panel>
+
+    </DockPanel>
 
   </Grid>
 

--- a/src/OpenIPC.Viewer.App/Views/Pages/SettingsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SettingsPage.axaml
@@ -455,7 +455,7 @@
             <Run Text="{Binding Version}" />
           </TextBlock>
 
-          <StackPanel Orientation="Horizontal" Spacing="8">
+          <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
             <Button Classes="outlined"
                     Content="{Binding [Settings.About.Repository], Source={x:Static svc:Localizer.Instance}}"
                     Command="{Binding OpenRepositoryCommand}" />
@@ -465,7 +465,7 @@
             <Button Classes="outlined"
                     Content="{Binding [Settings.Report.OpenLogs], Source={x:Static svc:Localizer.Instance}}"
                     Command="{Binding OpenLogsDirectoryCommand}" />
-          </StackPanel>
+          </WrapPanel>
 
           <!-- Config export / import (Phase 19.2) -->
           <Border Background="{StaticResource BorderWeakBrush}" Height="1" Margin="0,8" />
@@ -474,14 +474,14 @@
           <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
                      TextWrapping="Wrap"
                      Text="{Binding [Settings.Backup.Description], Source={x:Static svc:Localizer.Instance}}" />
-          <StackPanel Orientation="Horizontal" Spacing="8">
+          <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
             <Button Classes="outlined"
                     Content="{Binding [Settings.Backup.Export], Source={x:Static svc:Localizer.Instance}}"
                     Command="{Binding ExportConfigCommand}" />
             <Button Classes="outlined"
                     Content="{Binding [Settings.Backup.Import], Source={x:Static svc:Localizer.Instance}}"
                     Command="{Binding ImportConfigCommand}" />
-          </StackPanel>
+          </WrapPanel>
           <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
                      FontSize="{StaticResource FontSizeSm}"
                      Text="{Binding BackupStatus}"

--- a/src/OpenIPC.Viewer.App/Views/Pages/SingleCameraPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SingleCameraPage.axaml
@@ -243,19 +243,31 @@
           </TextBlock>
         </Grid>
 
-        <!-- Editable knobs -->
-        <Grid ColumnDefinitions="Auto,*,Auto,*,Auto,*,Auto,*,Auto,*" Margin="0,0,0,0">
-          <TextBlock Grid.Column="0" Text="{Binding [CameraPage.Majestic.Resolution], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" Margin="0,0,6,0" />
-          <ComboBox Grid.Column="1" ItemsSource="{Binding ResolutionOptions}" SelectedItem="{Binding DraftResolution, Mode=TwoWay}" MinWidth="120" />
-          <TextBlock Grid.Column="2" Text="{Binding [CameraPage.Majestic.Codec], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" Margin="10,0,6,0" />
-          <ComboBox Grid.Column="3" ItemsSource="{Binding CodecOptions}" SelectedItem="{Binding DraftCodec, Mode=TwoWay}" MinWidth="80" />
-          <TextBlock Grid.Column="4" Text="{Binding [CameraPage.Majestic.Fps], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" Margin="10,0,6,0" />
-          <ComboBox Grid.Column="5" ItemsSource="{Binding FpsOptions}" SelectedItem="{Binding DraftFps, Mode=TwoWay}" MinWidth="70" />
-          <TextBlock Grid.Column="6" Text="{Binding [CameraPage.Majestic.Bitrate], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" Margin="10,0,6,0" />
-          <NumericUpDown Grid.Column="7" Value="{Binding DraftBitrate, Mode=TwoWay}" Minimum="256" Maximum="16384" Increment="256" FormatString="0" MinWidth="100" />
-          <TextBlock Grid.Column="8" Text="{Binding [CameraPage.Majestic.Profile], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" Margin="10,0,6,0" />
-          <ComboBox Grid.Column="9" ItemsSource="{Binding ProfileOptions}" SelectedItem="{Binding DraftProfile, Mode=TwoWay}" MinWidth="100" />
-        </Grid>
+        <!-- Editable knobs. WrapPanel of label+control pairs so the five knobs
+             reflow across lines on a narrow viewport instead of running off the
+             right edge of a single 10-column row. -->
+        <WrapPanel Orientation="Horizontal" ItemSpacing="14" LineSpacing="8">
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="{Binding [CameraPage.Majestic.Resolution], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" />
+            <ComboBox ItemsSource="{Binding ResolutionOptions}" SelectedItem="{Binding DraftResolution, Mode=TwoWay}" MinWidth="120" />
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="{Binding [CameraPage.Majestic.Codec], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" />
+            <ComboBox ItemsSource="{Binding CodecOptions}" SelectedItem="{Binding DraftCodec, Mode=TwoWay}" MinWidth="80" />
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="{Binding [CameraPage.Majestic.Fps], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" />
+            <ComboBox ItemsSource="{Binding FpsOptions}" SelectedItem="{Binding DraftFps, Mode=TwoWay}" MinWidth="70" />
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="{Binding [CameraPage.Majestic.Bitrate], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" />
+            <NumericUpDown Value="{Binding DraftBitrate, Mode=TwoWay}" Minimum="256" Maximum="16384" Increment="256" FormatString="0" MinWidth="100" />
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" Spacing="6">
+            <TextBlock Text="{Binding [CameraPage.Majestic.Profile], Source={x:Static svc:Localizer.Instance}}" VerticalAlignment="Center" Foreground="{StaticResource TextSecondaryBrush}" FontSize="11" />
+            <ComboBox ItemsSource="{Binding ProfileOptions}" SelectedItem="{Binding DraftProfile, Mode=TwoWay}" MinWidth="100" />
+          </StackPanel>
+        </WrapPanel>
 
         <!-- RTMP push (Phase 11.7): checkbox + URL. Empty URL with toggle on
              is intentionally allowed — Majestic accepts it as "off". -->
@@ -273,48 +285,51 @@
                    FontSize="11" />
         </Grid>
 
-        <!-- Action row: night mode + apply + view raw + edit raw -->
-        <Grid ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto,Auto,Auto">
-          <Button Grid.Column="0" Content="{Binding [CameraPage.NightMode.Day], Source={x:Static svc:Localizer.Instance}}" Command="{Binding SetNightModeCommand}" CommandParameter="day"
-                  Padding="10,4" FontSize="11" Background="{StaticResource Bg3Brush}" Foreground="{StaticResource TextPrimaryBrush}" CornerRadius="4" Margin="0,0,4,0" />
-          <Button Grid.Column="1" Content="{Binding [CameraPage.NightMode.Night], Source={x:Static svc:Localizer.Instance}}" Command="{Binding SetNightModeCommand}" CommandParameter="night"
-                  Padding="10,4" FontSize="11" Background="{StaticResource Bg3Brush}" Foreground="{StaticResource TextPrimaryBrush}" CornerRadius="4" Margin="0,0,4,0" />
-          <Button Grid.Column="2" Content="{Binding [CameraPage.NightMode.Auto], Source={x:Static svc:Localizer.Instance}}" Command="{Binding SetNightModeCommand}" CommandParameter="auto"
-                  Padding="10,4" FontSize="11" Background="{StaticResource Bg3Brush}" Foreground="{StaticResource TextPrimaryBrush}" CornerRadius="4" />
+        <!-- Action row: night mode + apply + view raw + edit raw. WrapPanel so
+             the button cluster wraps on a narrow viewport. -->
+        <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
+          <StackPanel Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+            <Button Content="{Binding [CameraPage.NightMode.Day], Source={x:Static svc:Localizer.Instance}}" Command="{Binding SetNightModeCommand}" CommandParameter="day"
+                    Padding="10,4" FontSize="11" Background="{StaticResource Bg3Brush}" Foreground="{StaticResource TextPrimaryBrush}" CornerRadius="4" />
+            <Button Content="{Binding [CameraPage.NightMode.Night], Source={x:Static svc:Localizer.Instance}}" Command="{Binding SetNightModeCommand}" CommandParameter="night"
+                    Padding="10,4" FontSize="11" Background="{StaticResource Bg3Brush}" Foreground="{StaticResource TextPrimaryBrush}" CornerRadius="4" />
+            <Button Content="{Binding [CameraPage.NightMode.Auto], Source={x:Static svc:Localizer.Instance}}" Command="{Binding SetNightModeCommand}" CommandParameter="auto"
+                    Padding="10,4" FontSize="11" Background="{StaticResource Bg3Brush}" Foreground="{StaticResource TextPrimaryBrush}" CornerRadius="4" />
+          </StackPanel>
 
-          <TextBlock Grid.Column="3" Text="{Binding ApplyStatus}"
-                     VerticalAlignment="Center" Margin="14,0,8,0"
+          <TextBlock Text="{Binding ApplyStatus}"
+                     VerticalAlignment="Center"
                      FontSize="11"
                      Foreground="{StaticResource TextSecondaryBrush}"
                      IsVisible="{Binding ApplyStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
 
-          <Button Grid.Column="4" Content="{Binding [CameraPage.Majestic.ViewRaw], Source={x:Static svc:Localizer.Instance}}"
+          <Button Content="{Binding [CameraPage.Majestic.ViewRaw], Source={x:Static svc:Localizer.Instance}}"
                   Command="{Binding ToggleRawJsonCommand}"
                   Padding="10,4" FontSize="11"
                   Background="Transparent" BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
-                  CornerRadius="4" Foreground="{StaticResource TextPrimaryBrush}" Margin="0,0,8,0" />
-          <Button Grid.Column="5" Content="{Binding [CameraPage.Majestic.EditRaw], Source={x:Static svc:Localizer.Instance}}"
+                  CornerRadius="4" Foreground="{StaticResource TextPrimaryBrush}" />
+          <Button Content="{Binding [CameraPage.Majestic.EditRaw], Source={x:Static svc:Localizer.Instance}}"
                   Command="{Binding EditRawConfigCommand}"
                   IsVisible="{Binding IsRawConfigEditorEnabled}"
                   IsEnabled="{Binding !ApplyInProgress}"
                   Padding="10,4" FontSize="11"
                   Background="Transparent" BorderBrush="{StaticResource WarningBrush}" BorderThickness="1"
-                  CornerRadius="4" Foreground="{StaticResource WarningBrush}" Margin="0,0,8,0" />
-          <Button Grid.Column="6" Content="{Binding [Common.Apply], Source={x:Static svc:Localizer.Instance}}"
+                  CornerRadius="4" Foreground="{StaticResource WarningBrush}" />
+          <Button Content="{Binding [Common.Apply], Source={x:Static svc:Localizer.Instance}}"
                   Command="{Binding ApplyConfigCommand}"
                   IsEnabled="{Binding !ApplyInProgress}"
                   Padding="14,4" FontSize="11"
                   Background="{StaticResource AccentBrush}" Foreground="White" CornerRadius="4" />
           <!-- SSH fallback for majestic.yaml (Phase 13.5) — advanced opt-in,
                works when the HTTP API is disabled. -->
-          <Button Grid.Column="7" Content="{Binding [CameraPage.Majestic.EditRawSsh], Source={x:Static svc:Localizer.Instance}}"
+          <Button Content="{Binding [CameraPage.Majestic.EditRawSsh], Source={x:Static svc:Localizer.Instance}}"
                   Command="{Binding EditMajesticOverSshCommand}"
                   IsVisible="{Binding IsRawConfigEditorEnabled}"
                   IsEnabled="{Binding !ApplyInProgress}"
-                  Padding="10,4" FontSize="11" Margin="8,0,0,0"
+                  Padding="10,4" FontSize="11"
                   Background="Transparent" BorderBrush="{StaticResource WarningBrush}" BorderThickness="1"
                   CornerRadius="4" Foreground="{StaticResource WarningBrush}" />
-        </Grid>
+        </WrapPanel>
 
         <!-- Errors -->
         <TextBlock Text="{Binding MajesticError}"
@@ -345,17 +360,18 @@
       </StackPanel>
     </Border>
 
-    <!-- Bottom bar. Hidden in landscape fullscreen. -->
-    <Grid Grid.Row="3" ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto" Margin="0,12,0,0"
-          IsVisible="{Binding !IsFullscreen}">
+    <!-- Bottom bar. Hidden in landscape fullscreen. A WrapPanel so the transport
+         controls flow onto extra lines on a phone instead of overflowing the
+         6-column row off the right edge. -->
+    <WrapPanel Grid.Row="3" Orientation="Horizontal" ItemSpacing="8" LineSpacing="8"
+               Margin="0,12,0,0"
+               IsVisible="{Binding !IsFullscreen}">
 
       <!-- REC indicator (visible while recording) -->
-      <Border Grid.Column="0"
-              IsVisible="{Binding IsRecording}"
+      <Border IsVisible="{Binding IsRecording}"
               Background="{StaticResource DangerBrush}"
               CornerRadius="4"
               Padding="8,4"
-              Margin="0,0,12,0"
               VerticalAlignment="Center">
         <TextBlock Text="{Binding RecordingElapsed}"
                    FontFamily="{StaticResource FontMono}"
@@ -363,8 +379,7 @@
                    Foreground="White" />
       </Border>
 
-      <StackPanel Grid.Column="1"
-                  Orientation="Horizontal"
+      <StackPanel Orientation="Horizontal"
                   Spacing="6"
                   IsVisible="{Binding SnapshotPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                   VerticalAlignment="Center">
@@ -400,11 +415,9 @@
 
       <!-- Audio listen (Phase 17.3): speaker toggle + volume. Shown only when a
            native sink exists AND the camera actually has audio. Muted by default. -->
-      <StackPanel Grid.Column="2"
-                  Orientation="Horizontal"
+      <StackPanel Orientation="Horizontal"
                   Spacing="8"
                   VerticalAlignment="Center"
-                  Margin="0,0,8,0"
                   IsVisible="{Binding IsAudioControlVisible}">
         <Button Command="{Binding ToggleMuteCommand}"
                 Background="Transparent"
@@ -432,11 +445,9 @@
 
       <!-- Majestic audio-off hint (Phase 17.4): shown instead of the speaker when
            the camera supports audio but has it disabled in config. -->
-      <StackPanel Grid.Column="2"
-                  Orientation="Horizontal"
+      <StackPanel Orientation="Horizontal"
                   Spacing="8"
                   VerticalAlignment="Center"
-                  Margin="0,0,8,0"
                   IsVisible="{Binding ShowEnableAudioHint}">
         <TextBlock Text="{Binding [CameraPage.Audio.DisabledHint], Source={x:Static svc:Localizer.Instance}}"
                    Foreground="{StaticResource TextSecondaryBrush}"
@@ -455,15 +466,14 @@
 
       <!-- Push-to-talk (Phase 17.6): mic → camera speaker. Shown when a mic
            exists; active state highlighted. -->
-      <Button Grid.Column="3"
-              x:Name="TalkButton"
+      <Button x:Name="TalkButton"
               IsVisible="{Binding CanTalk}"
               Background="Transparent"
               BorderBrush="{StaticResource BorderMediumBrush}"
               BorderThickness="1"
               Padding="14,8"
               CornerRadius="6"
-              Margin="0,0,8,0"
+              VerticalAlignment="Center"
               ToolTip.Tip="{Binding [CameraPage.Tooltip.Talk], Source={x:Static svc:Localizer.Instance}}">
         <Panel>
           <!-- Accent mic while transmitting, neutral otherwise. -->
@@ -476,35 +486,33 @@
         </Panel>
       </Button>
 
-      <Button Grid.Column="4"
-              Command="{Binding ToggleRecordingCommand}"
+      <Button Command="{Binding ToggleRecordingCommand}"
               IsVisible="{Binding !IsRecording}"
               Background="Transparent"
               BorderBrush="{StaticResource BorderMediumBrush}"
               BorderThickness="1"
               Padding="14,8"
               CornerRadius="6"
+              VerticalAlignment="Center"
               Foreground="{StaticResource DangerBrush}"
-              Content="● REC"
-              Margin="0,0,8,0" />
-      <Button Grid.Column="4"
-              Command="{Binding ToggleRecordingCommand}"
+              Content="● REC" />
+      <Button Command="{Binding ToggleRecordingCommand}"
               IsVisible="{Binding IsRecording}"
               Background="{StaticResource DangerBrush}"
               Foreground="White"
               Padding="14,8"
               CornerRadius="6"
-              Content="{Binding [CameraPage.Stop], Source={x:Static svc:Localizer.Instance}}"
-              Margin="0,0,8,0" />
+              VerticalAlignment="Center"
+              Content="{Binding [CameraPage.Stop], Source={x:Static svc:Localizer.Instance}}" />
 
-      <Button Grid.Column="5"
-              Content="{Binding [CameraPage.Snapshot], Source={x:Static svc:Localizer.Instance}}"
+      <Button Content="{Binding [CameraPage.Snapshot], Source={x:Static svc:Localizer.Instance}}"
               Command="{Binding SnapshotCommand}"
               Background="{StaticResource AccentBrush}"
               Foreground="White"
               Padding="14,8"
-              CornerRadius="6" />
-    </Grid>
+              CornerRadius="6"
+              VerticalAlignment="Center" />
+    </WrapPanel>
 
   </Grid>
 

--- a/src/OpenIPC.Viewer.App/Views/Pages/SnapshotBrowserView.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SnapshotBrowserView.axaml
@@ -39,33 +39,31 @@
 
   <Grid RowDefinitions="Auto,Auto,Auto,*">
 
-    <!-- Filters -->
-    <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" Margin="0,0,0,10">
-      <ComboBox Grid.Column="0"
-                MinWidth="160"
+    <!-- Filters. WrapPanel so the camera picker, date presets and sort toggle
+         flow onto a second line instead of overflowing a phone-width viewport. -->
+    <WrapPanel Grid.Row="0" Orientation="Horizontal" ItemSpacing="8" LineSpacing="8"
+               Margin="0,0,0,10">
+      <ComboBox MinWidth="160"
                 ItemsSource="{Binding CameraOptions}"
                 SelectedItem="{Binding SelectedCamera}" />
 
-      <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" Margin="12,0,0,0"
-                  VerticalAlignment="Center">
-        <Button Classes="seg" Classes.active="{Binding IsPresetAll}"
-                Command="{Binding SetPresetCommand}" CommandParameter="all"
-                Content="{Binding [Snapshots.PresetAll], Source={x:Static svc:Localizer.Instance}}" />
-        <Button Classes="seg" Classes.active="{Binding IsPresetToday}"
-                Command="{Binding SetPresetCommand}" CommandParameter="today"
-                Content="{Binding [Snapshots.PresetToday], Source={x:Static svc:Localizer.Instance}}" />
-        <Button Classes="seg" Classes.active="{Binding IsPreset7}"
-                Command="{Binding SetPresetCommand}" CommandParameter="7"
-                Content="{Binding [Snapshots.Preset7], Source={x:Static svc:Localizer.Instance}}" />
-        <Button Classes="seg" Classes.active="{Binding IsPreset30}"
-                Command="{Binding SetPresetCommand}" CommandParameter="30"
-                Content="{Binding [Snapshots.Preset30], Source={x:Static svc:Localizer.Instance}}" />
-      </StackPanel>
+      <Button Classes="seg" Classes.active="{Binding IsPresetAll}"
+              Command="{Binding SetPresetCommand}" CommandParameter="all"
+              Content="{Binding [Snapshots.PresetAll], Source={x:Static svc:Localizer.Instance}}" />
+      <Button Classes="seg" Classes.active="{Binding IsPresetToday}"
+              Command="{Binding SetPresetCommand}" CommandParameter="today"
+              Content="{Binding [Snapshots.PresetToday], Source={x:Static svc:Localizer.Instance}}" />
+      <Button Classes="seg" Classes.active="{Binding IsPreset7}"
+              Command="{Binding SetPresetCommand}" CommandParameter="7"
+              Content="{Binding [Snapshots.Preset7], Source={x:Static svc:Localizer.Instance}}" />
+      <Button Classes="seg" Classes.active="{Binding IsPreset30}"
+              Command="{Binding SetPresetCommand}" CommandParameter="30"
+              Content="{Binding [Snapshots.Preset30], Source={x:Static svc:Localizer.Instance}}" />
 
-      <Button Grid.Column="2" Classes="seg"
+      <Button Classes="seg"
               Command="{Binding ToggleSortCommand}"
               Content="{Binding SortLabel}" />
-    </Grid>
+    </WrapPanel>
 
     <!-- Selection toolbar -->
     <Border Grid.Row="1" IsVisible="{Binding HasSelection}"


### PR DESCRIPTION
- add Adaptive.CompactBelow behaviour that toggles a `compact` class by width
- Recordings: stack calendar above the list and wrap row metadata/actions
- wrap overflowing button rows in SingleCamera, RecordingPlayer, Snapshots, Events, Settings
- Majestic knobs/actions wrap instead of a fixed 10-column row

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- add Adaptive.CompactBelow behaviour that toggles a `compact` class by width
- Recordings: stack calendar above the list and wrap row metadata/actions
- wrap overflowing button rows in SingleCamera, RecordingPlayer, Snapshots, Events, Settings
- Majestic knobs/actions wrap instead of a fixed 10-column row

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
