### PR TITLE
fix: make ONVIF/Majestic/audio work with real OpenIPC cameras

### DIFF
--- a/src/OpenIPC.Viewer.App/Controls/DetectionOverlay.cs
+++ b/src/OpenIPC.Viewer.App/Controls/DetectionOverlay.cs
@@ -8,8 +8,10 @@ using OpenIPC.Viewer.Core.Analytics;
 namespace OpenIPC.Viewer.App.Controls;
 
 // Draws detection boxes + labels over the video tile (Phase 15.5). Boxes are
-// normalized 0..1 in the source frame, so we just scale them to Bounds — no
-// dependency on the model input size. Rendered directly (a Canvas of one box
+// normalized 0..1 in the source frame. The video below renders with
+// Stretch="Uniform" (letterboxed), so we map into the same fitted rect using
+// SourceAspect rather than the full Bounds — otherwise boxes drift whenever the
+// frame aspect differs from the tile's. Rendered directly (a Canvas of one box
 // per visual would churn the tree); we repaint on each new detection result.
 public sealed class DetectionOverlay : Control
 {
@@ -18,6 +20,10 @@ public sealed class DetectionOverlay : Control
 
     public static readonly StyledProperty<bool> ShowBoxesProperty =
         AvaloniaProperty.Register<DetectionOverlay, bool>(nameof(ShowBoxes), defaultValue: true);
+
+    // Source frame aspect (width/height). 0 → map to full Bounds (legacy).
+    public static readonly StyledProperty<double> SourceAspectProperty =
+        AvaloniaProperty.Register<DetectionOverlay, double>(nameof(SourceAspect));
 
     // Distinct hues per class id so different objects read apart at a glance.
     private static readonly Color[] Palette =
@@ -30,7 +36,7 @@ public sealed class DetectionOverlay : Control
 
     static DetectionOverlay()
     {
-        AffectsRender<DetectionOverlay>(DetectionsProperty, ShowBoxesProperty);
+        AffectsRender<DetectionOverlay>(DetectionsProperty, ShowBoxesProperty, SourceAspectProperty);
     }
 
     public IReadOnlyList<Detection>? Detections
@@ -45,6 +51,12 @@ public sealed class DetectionOverlay : Control
         set => SetValue(ShowBoxesProperty, value);
     }
 
+    public double SourceAspect
+    {
+        get => GetValue(SourceAspectProperty);
+        set => SetValue(SourceAspectProperty, value);
+    }
+
     public override void Render(DrawingContext context)
     {
         base.Render(context);
@@ -55,15 +67,19 @@ public sealed class DetectionOverlay : Control
         var h = Bounds.Height;
         if (w <= 0 || h <= 0) return;
 
+        // Match the video's Stretch="Uniform" fit: shrink the mapping rect to the
+        // letterboxed area so boxes sit on the actual pixels, not the black bars.
+        var (contentX, contentY, contentW, contentH) = FitUniform(w, h, SourceAspect);
+
         foreach (var d in detections)
         {
             var color = Palette[((d.ClassId % Palette.Length) + Palette.Length) % Palette.Length];
             var pen = new Pen(new SolidColorBrush(color), 2);
 
-            var x = d.X * w;
-            var y = d.Y * h;
-            var bw = d.Width * w;
-            var bh = d.Height * h;
+            var x = contentX + d.X * contentW;
+            var y = contentY + d.Y * contentH;
+            var bw = d.Width * contentW;
+            var bh = d.Height * contentH;
             var box = new Rect(x, y, bw, bh);
             context.DrawRectangle(null, pen, box);
 
@@ -77,5 +93,24 @@ public sealed class DetectionOverlay : Control
             context.DrawRectangle(new SolidColorBrush(color), null, new Rect(x, labelY, labelW, labelH));
             context.DrawText(text, new Point(x + 4, labelY + 1));
         }
+    }
+
+    // The rect a Stretch="Uniform" image occupies inside w×h. aspect<=0 (size not
+    // yet known) → fill the whole area, matching the pre-fix behavior.
+    private static (double X, double Y, double W, double H) FitUniform(double w, double h, double aspect)
+    {
+        if (aspect <= 0) return (0, 0, w, h);
+
+        var boundsAspect = w / h;
+        if (boundsAspect > aspect)
+        {
+            // Tile wider than the frame → pillarbox (bars left/right).
+            var contentW = h * aspect;
+            return ((w - contentW) / 2, 0, contentW, h);
+        }
+
+        // Tile taller than the frame → letterbox (bars top/bottom).
+        var contentH = w / aspect;
+        return (0, (h - contentH) / 2, w, contentH);
     }
 }

--- a/src/OpenIPC.Viewer.App/Services/DialogService.cs
+++ b/src/OpenIPC.Viewer.App/Services/DialogService.cs
@@ -230,12 +230,13 @@ public sealed class DialogService : IDialogService
         await dlg.ShowDialog(owner);
     }
 
-    public Task<string?> ShowRawConfigEditorAsync(string initialJson)
+    public Task<string?> ShowRawConfigEditorAsync(string initialJson, bool validateJson = true)
     {
         if (OverlayDialogPresenter.IsMobile)
         {
             var content = new RawConfigEditorContent();
             content.SetInitialText(initialJson);
+            content.SetValidateJson(validateJson);
             return OverlayDialogPresenter.ShowAsync(content, content.Completion);
         }
 
@@ -243,6 +244,7 @@ public sealed class DialogService : IDialogService
         if (owner is null) return Task.FromResult<string?>(null);
         var dlg = new RawConfigEditorDialog();
         dlg.SetInitialText(initialJson);
+        dlg.SetValidateJson(validateJson);
         return dlg.ShowDialog<string?>(owner);
     }
 

--- a/src/OpenIPC.Viewer.App/Services/IDialogService.cs
+++ b/src/OpenIPC.Viewer.App/Services/IDialogService.cs
@@ -49,8 +49,10 @@ public interface IDialogService
     // mutates the layout live; completes when the dialog is dismissed.
     Task ShowManageLayoutCamerasAsync(ManageLayoutCamerasViewModel viewModel);
 
-    // Returns the edited JSON if the user clicked Apply, null if cancelled.
-    Task<string?> ShowRawConfigEditorAsync(string initialJson);
+    // Returns the edited text if the user clicked Apply, null if cancelled.
+    // validateJson gates the Apply button on JSON well-formedness; pass false
+    // for the SSH path, which edits majestic.yaml (YAML, not JSON).
+    Task<string?> ShowRawConfigEditorAsync(string initialJson, bool validateJson = true);
 
     // Opens a URI in the system browser via the platform launcher. Returns
     // false if no TopLevel is available or the launch was rejected.

--- a/src/OpenIPC.Viewer.App/Services/UserSettings.cs
+++ b/src/OpenIPC.Viewer.App/Services/UserSettings.cs
@@ -50,7 +50,16 @@ public sealed record UserSettings(
     int NotificationCooldownSeconds = 30,
     bool QuietHoursEnabled = false,
     int QuietHoursStartHour = 22,
-    int QuietHoursEndHour = 7)
+    int QuietHoursEndHour = 7,
+    // Main window geometry (desktop only). Null position = never saved yet →
+    // center on first run. Size is the client area in DIPs; defaults match the
+    // MainWindow.axaml fallback. WindowMaximized restores a maximized window
+    // while keeping the normal-state bounds above for un-maximize.
+    int? WindowX = null,
+    int? WindowY = null,
+    double WindowWidth = 1200,
+    double WindowHeight = 780,
+    bool WindowMaximized = false)
 {
     public static UserSettings Default => new();
 }

--- a/src/OpenIPC.Viewer.App/ViewModels/CameraTileViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/CameraTileViewModel.cs
@@ -62,6 +62,7 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(StatsLabel))]
     [NotifyPropertyChangedFor(nameof(HasStats))]
+    [NotifyPropertyChangedFor(nameof(SourceAspect))]
     private SessionTelemetry? _telemetry;
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ErrorDetail))]
@@ -120,6 +121,12 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
     }
 
     public bool HasStats => Telemetry is not null;
+
+    // Source frame aspect ratio (width/height), so the DetectionOverlay can map
+    // normalized boxes into the letterboxed video rect instead of the full tile
+    // bounds. 0 until the first telemetry arrives → overlay falls back to bounds.
+    public double SourceAspect =>
+        Telemetry is { Width: > 0, Height: > 0 } t ? (double)t.Width / t.Height : 0;
 
     // Bottom-right stats badge: codec • resolution • fps • bitrate.
     public string? StatsLabel

--- a/src/OpenIPC.Viewer.App/ViewModels/GridPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/GridPageViewModel.cs
@@ -133,7 +133,7 @@ public sealed partial class GridPageViewModel : ViewModelBase,
     [RelayCommand]
     private async Task SetLayoutAsync(string size)
     {
-        if (!int.TryParse(size, out var n) || n < 1 || n > 3) return;
+        if (!int.TryParse(size, out var n) || n < 1 || n > 5) return;
         LayoutSize = n;
         if (ActiveLayout is { } a)
         {
@@ -244,7 +244,7 @@ public sealed partial class GridPageViewModel : ViewModelBase,
 
     private async Task RefreshTilesAsync(CancellationToken ct)
     {
-        // Two caps stack: the layout selector (1/2x2/3x3 = up to 9 slots) and
+        // Two caps stack: the layout selector (1×1 … 5×5 = up to 25 slots) and
         // the Settings → Video → MaxConcurrentGridSessions ceiling. The lower
         // of the two wins, so a "max 4" user with a 3x3 grid sees 4 live tiles
         // and 5 empty placeholders (which still render via the Slots padding

--- a/src/OpenIPC.Viewer.App/ViewModels/MainWindowViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/MainWindowViewModel.cs
@@ -25,6 +25,10 @@ public sealed partial class MainWindowViewModel : ViewModelBase,
     private SingleCameraPageViewModel? _activeSingleCamera;
     private RecordingPlayerPageViewModel? _activePlayer;
 
+    // The page the single-camera view was opened from (grid vs library), so
+    // Back returns there instead of always dropping to the library list.
+    private ViewModelBase? _singleCameraOrigin;
+
     public GridPageViewModel Live { get; }
     public CameraLibraryPageViewModel Library { get; }
     public RecordingsPageViewModel Recordings { get; }
@@ -151,6 +155,11 @@ public sealed partial class MainWindowViewModel : ViewModelBase,
             }
 
             await DisposeActiveSingleCameraAsync().ConfigureAwait(true);
+            // Camera-to-camera swipe re-enters this with a single-camera page
+            // already current; keep the original entry page so Back still lands
+            // where the user started (the live grid or the library list).
+            if (CurrentPage is not SingleCameraPageViewModel)
+                _singleCameraOrigin = CurrentPage;
             _activeSingleCamera = _singleCameraFactory.Create(camera);
             CurrentPage = _activeSingleCamera;
         }
@@ -163,7 +172,8 @@ public sealed partial class MainWindowViewModel : ViewModelBase,
     public async void Receive(GoBackToLibraryMessage message)
     {
         await DisposeActiveSingleCameraAsync().ConfigureAwait(true);
-        CurrentPage = Library;
+        CurrentPage = _singleCameraOrigin ?? Library;
+        _singleCameraOrigin = null;
     }
 
     public void Receive(OpenRecordingMessage message)

--- a/src/OpenIPC.Viewer.App/ViewModels/SingleCameraPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/SingleCameraPageViewModel.cs
@@ -726,7 +726,8 @@ public sealed partial class SingleCameraPageViewModel : ViewModelBase, IAsyncDis
             return;
         }
 
-        var edited = await _dialogs.ShowRawConfigEditorAsync(initial).ConfigureAwait(true);
+        // majestic.yaml is YAML, not JSON — don't gate Apply on JSON validity.
+        var edited = await _dialogs.ShowRawConfigEditorAsync(initial, validateJson: false).ConfigureAwait(true);
         if (edited is null || edited == initial) return;
 
         ApplyInProgress = true;

--- a/src/OpenIPC.Viewer.App/ViewModels/SingleCameraPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/SingleCameraPageViewModel.cs
@@ -328,6 +328,16 @@ public sealed partial class SingleCameraPageViewModel : ViewModelBase, IAsyncDis
     private bool _talkUnsupported;
     public bool CanTalk => _talk.IsAvailable && !(_camera.OnvifEnabled && !_camera.HasAudioOut) && !_talkUnsupported;
 
+    // Two-way audio capability, probed once on activation (OPTIONS + DESCRIBE):
+    // null = not yet known, true = camera advertises a backchannel track,
+    // false = it doesn't. Drives a status hint so the user knows whether talk
+    // will work without having to press it.
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TwoWayAudioUnsupported))]
+    private bool? _twoWayAudioCapable;
+
+    public bool TwoWayAudioUnsupported => TwoWayAudioCapable == false;
+
     [ObservableProperty] private bool _isTalking;
     [ObservableProperty] private string? _talkError;
 
@@ -368,6 +378,36 @@ public sealed partial class SingleCameraPageViewModel : ViewModelBase, IAsyncDis
     {
         _talkHeld = false;
         await _talk.StopAsync().ConfigureAwait(true);
+    }
+
+    // Best-effort capability probe, run fire-and-forget after the stream is up.
+    // Never throws into the caller; leaves capability "unknown" on any failure so
+    // the talk button stays available and degrades gracefully on press.
+    private async Task ProbeTwoWayAudioAsync(CameraCredentials? creds, CancellationToken ct)
+    {
+        if (TwoWayAudioCapable is not null) return;            // probe once per page
+        if (!_talk.IsAvailable) return;                        // no mic → nothing to indicate
+        if (_camera.OnvifEnabled && !_camera.HasAudioOut) return; // ONVIF already says no speaker
+        try
+        {
+            var ep = new BackchannelEndpoint(_camera.RtspMainUri, creds);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(8));
+            var ok = await _talk.ProbeAsync(ep, cts.Token).ConfigureAwait(false);
+            Dispatcher.UIThread.Post(() =>
+            {
+                TwoWayAudioCapable = ok;
+                if (!ok)
+                {
+                    _talkUnsupported = true;
+                    OnPropertyChanged(nameof(CanTalk));
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Two-way audio probe failed for {CameraId}", _camera.Id);
+        }
     }
 
     private void OnTalkChanged(object? sender, EventArgs e)
@@ -524,6 +564,9 @@ public sealed partial class SingleCameraPageViewModel : ViewModelBase, IAsyncDis
                 await InitPtzAsync(creds, ct).ConfigureAwait(true);
 
             await InitMajesticAsync(creds, ct).ConfigureAwait(true);
+
+            // Capability probe in the background — must not block activation.
+            _ = ProbeTwoWayAudioAsync(creds, ct);
         }
         finally
         {

--- a/src/OpenIPC.Viewer.App/Views/Dialogs/RawConfigEditorContent.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/RawConfigEditorContent.axaml.cs
@@ -10,6 +10,8 @@ namespace OpenIPC.Viewer.App.Views.Dialogs;
 public sealed partial class RawConfigEditorContent : UserControl
 {
     private readonly TaskCompletionSource<string?> _tcs = new();
+    private readonly TextEditor _editor;
+    private bool _validateJson = true;
 
     public Task<string?> Completion => _tcs.Task;
 
@@ -17,8 +19,8 @@ public sealed partial class RawConfigEditorContent : UserControl
     {
         InitializeComponent();
 
-        var editor = this.FindControl<TextEditor>("Editor")!;
-        editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("Json");
+        _editor = this.FindControl<TextEditor>("Editor")!;
+        _editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("Json");
         var apply = this.FindControl<Button>("ApplyButton")!;
         var cancel = this.FindControl<Button>("CancelButton")!;
         var error = this.FindControl<TextBlock>("ErrorBlock")!;
@@ -26,23 +28,34 @@ public sealed partial class RawConfigEditorContent : UserControl
         cancel.Click += (_, _) => _tcs.TrySetResult(null);
         apply.Click += (_, _) =>
         {
-            try
+            // The SSH path edits majestic.yaml (YAML, not JSON); only gate on
+            // JSON well-formedness for the HTTP config.json editor. The camera
+            // validates the YAML itself on reload.
+            if (_validateJson)
             {
-                using var _ = JsonDocument.Parse(editor.Text);
+                try
+                {
+                    using var _ = JsonDocument.Parse(_editor.Text);
+                }
+                catch (JsonException ex)
+                {
+                    error.Text = string.Format(Localizer.Instance["RawConfigEditor.InvalidJsonFormat"], ex.Message);
+                    error.IsVisible = true;
+                    return;
+                }
             }
-            catch (JsonException ex)
-            {
-                error.Text = string.Format(Localizer.Instance["RawConfigEditor.InvalidJsonFormat"], ex.Message);
-                error.IsVisible = true;
-                return;
-            }
-            _tcs.TrySetResult(editor.Text);
+            _tcs.TrySetResult(_editor.Text);
         };
     }
 
-    public void SetInitialText(string text)
+    public void SetInitialText(string text) => _editor.Text = text;
+
+    // When false, the editor holds YAML (majestic.yaml over SSH): skip the JSON
+    // validation gate and drop the JSON syntax highlighting.
+    public void SetValidateJson(bool validate)
     {
-        var editor = this.FindControl<TextEditor>("Editor")!;
-        editor.Text = text;
+        _validateJson = validate;
+        if (!validate)
+            _editor.SyntaxHighlighting = null;
     }
 }

--- a/src/OpenIPC.Viewer.App/Views/Dialogs/RawConfigEditorDialog.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/RawConfigEditorDialog.axaml.cs
@@ -17,4 +17,6 @@ public sealed partial class RawConfigEditorDialog : Window
     }
 
     public void SetInitialText(string text) => _content.SetInitialText(text);
+
+    public void SetValidateJson(bool validate) => _content.SetValidateJson(validate);
 }

--- a/src/OpenIPC.Viewer.App/Views/MainWindow.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/MainWindow.axaml.cs
@@ -1,17 +1,127 @@
+using System;
+using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using OpenIPC.Viewer.App.Messages;
+using OpenIPC.Viewer.App.Services;
 
 namespace OpenIPC.Viewer.App.Views;
 
 public sealed partial class MainWindow : Window
 {
+    private readonly UserSettingsService? _settings;
     private WindowState _previousState = WindowState.Normal;
+
+    // Last known normal-state geometry, tracked live so a window that closes
+    // while maximized still persists sensible un-maximize bounds.
+    private PixelPoint _normalPosition;
+    private Size _normalSize;
 
     public MainWindow()
     {
         InitializeComponent();
+
+        _settings = App.Services?.GetService<UserSettingsService>();
+        RestoreGeometry();
+
         PropertyChanged += OnWindowPropertyChanged;
+        PositionChanged += (_, _) => CaptureNormalBounds();
+        SizeChanged += (_, _) => CaptureNormalBounds();
+        Closing += OnClosing;
+    }
+
+    // Apply the saved size/position before the window is shown so it opens in
+    // place — no visible jump. Falls back to centered on first run (no saved X).
+    private void RestoreGeometry()
+    {
+        var s = _settings?.Current;
+        if (s is null)
+        {
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+            return;
+        }
+
+        if (s.WindowWidth > 0) Width = s.WindowWidth;
+        if (s.WindowHeight > 0) Height = s.WindowHeight;
+
+        if (s.WindowX is { } x && s.WindowY is { } y)
+        {
+            WindowStartupLocation = WindowStartupLocation.Manual;
+            Position = new PixelPoint(x, y);
+        }
+        else
+        {
+            WindowStartupLocation = WindowStartupLocation.CenterScreen;
+        }
+
+        _normalPosition = Position;
+        _normalSize = new Size(Width, Height);
+
+        if (s.WindowMaximized)
+            WindowState = WindowState.Maximized;
+    }
+
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+        EnsureOnScreen();
+    }
+
+    // Guard against a saved position that lands on a now-disconnected monitor:
+    // if the window rect intersects no screen, recenter on the primary one.
+    private void EnsureOnScreen()
+    {
+        if (WindowState == WindowState.Maximized) return;
+        var screens = Screens;
+        if (screens is null || screens.All.Count == 0) return;
+
+        var size = new PixelSize(
+            Math.Max(1, (int)(ClientSize.Width * RenderScaling)),
+            Math.Max(1, (int)(ClientSize.Height * RenderScaling)));
+        var rect = new PixelRect(Position, size);
+
+        if (screens.All.Any(scr => scr.Bounds.Intersects(rect)))
+            return;
+
+        var target = screens.Primary ?? screens.All[0];
+        var wa = target.WorkingArea;
+        Position = new PixelPoint(
+            wa.X + Math.Max(0, (wa.Width - size.Width) / 2),
+            wa.Y + Math.Max(0, (wa.Height - size.Height) / 2));
+        _normalPosition = Position;
+    }
+
+    private void CaptureNormalBounds()
+    {
+        if (WindowState != WindowState.Normal) return;
+        _normalPosition = Position;
+        _normalSize = ClientSize;
+    }
+
+    private void OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (_settings is null) return;
+
+        // Maximized close → keep the tracked normal bounds; otherwise snapshot
+        // the live geometry. Minimized is treated as normal (we never persist a
+        // minimized window).
+        var maximized = WindowState == WindowState.Maximized;
+        if (!maximized) CaptureNormalBounds();
+
+        var next = _settings.Current with
+        {
+            WindowX = _normalPosition.X,
+            WindowY = _normalPosition.Y,
+            WindowWidth = _normalSize.Width > 0 ? _normalSize.Width : _settings.Current.WindowWidth,
+            WindowHeight = _normalSize.Height > 0 ? _normalSize.Height : _settings.Current.WindowHeight,
+            WindowMaximized = maximized,
+        };
+
+        // Synchronous so the write completes before the process exits; the save
+        // is off-UI file IO (ConfigureAwait(false)) so this won't deadlock.
+        _settings.UpdateAsync(next).GetAwaiter().GetResult();
     }
 
     private void OnWindowPropertyChanged(object? sender, Avalonia.AvaloniaPropertyChangedEventArgs e)

--- a/src/OpenIPC.Viewer.App/Views/Pages/GridPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/GridPage.axaml
@@ -35,6 +35,16 @@
                 Background="{StaticResource Bg2Brush}"
                 BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
                 Foreground="{StaticResource TextPrimaryBrush}" />
+        <Button Content="4×4" Command="{Binding SetLayoutCommand}" CommandParameter="4"
+                Padding="10,6" CornerRadius="6"
+                Background="{StaticResource Bg2Brush}"
+                BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
+                Foreground="{StaticResource TextPrimaryBrush}" />
+        <Button Content="5×5" Command="{Binding SetLayoutCommand}" CommandParameter="5"
+                Padding="10,6" CornerRadius="6"
+                Background="{StaticResource Bg2Brush}"
+                BorderBrush="{StaticResource BorderMediumBrush}" BorderThickness="1"
+                Foreground="{StaticResource TextPrimaryBrush}" />
       </StackPanel>
     </Grid>
 
@@ -146,6 +156,7 @@
                       <!-- AI detection boxes (Phase 15.5), above the video. -->
                       <controls:DetectionOverlay Detections="{Binding Detections}"
                                                  ShowBoxes="{Binding AnalyticsEnabled}"
+                                                 SourceAspect="{Binding SourceAspect}"
                                                  IsHitTestVisible="False" />
 
                       <!-- Top-left: name -->

--- a/src/OpenIPC.Viewer.App/Views/Pages/SingleCameraPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SingleCameraPage.axaml
@@ -486,6 +486,17 @@
         </Panel>
       </Button>
 
+      <!-- Two-way audio capability hint: shown when the probe found the camera
+           advertises no RTSP backchannel, so the missing talk button is explained. -->
+      <TextBlock VerticalAlignment="Center"
+                 FontSize="11"
+                 Opacity="0.7"
+                 MaxWidth="180"
+                 TextWrapping="Wrap"
+                 Foreground="{StaticResource TextPrimaryBrush}"
+                 IsVisible="{Binding TwoWayAudioUnsupported}"
+                 Text="{Binding [CameraPage.Talk.Unsupported], Source={x:Static svc:Localizer.Instance}}" />
+
       <Button Command="{Binding ToggleRecordingCommand}"
               IsVisible="{Binding !IsRecording}"
               Background="Transparent"

--- a/src/OpenIPC.Viewer.Core/Video/AudioBackchannel.cs
+++ b/src/OpenIPC.Viewer.Core/Video/AudioBackchannel.cs
@@ -19,6 +19,13 @@ public interface IAudioBackchannelClient
     // "this camera has no speaker" case — not an error). Throws only on a real
     // connection / auth / protocol failure.
     Task<IAudioBackchannelSession?> OpenAsync(BackchannelEndpoint endpoint, CancellationToken ct);
+
+    // Lightweight capability check: OPTIONS + DESCRIBE only (no SETUP/PLAY).
+    // Returns true if the camera advertises a backchannel audio track, so the UI
+    // can show whether two-way audio works without the user pressing talk.
+    // Throws on a real connection / auth / protocol failure (caller treats that
+    // as "unknown").
+    Task<bool> ProbeAsync(BackchannelEndpoint endpoint, CancellationToken ct);
 }
 
 // Outcome of PushToTalkController.StartAsync — lets the UI tell "camera has no

--- a/src/OpenIPC.Viewer.Core/Video/PushToTalkController.cs
+++ b/src/OpenIPC.Viewer.Core/Video/PushToTalkController.cs
@@ -35,6 +35,12 @@ public sealed class PushToTalkController : IAsyncDisposable
     public event EventHandler? StateChanged;
     public event EventHandler<string>? Error;
 
+    // Capability probe (OPTIONS + DESCRIBE only) so the UI can show whether the
+    // camera offers two-way audio before the user presses talk. Throws on a real
+    // connection/auth failure — the caller treats that as "unknown".
+    public Task<bool> ProbeAsync(BackchannelEndpoint endpoint, CancellationToken ct) =>
+        _client.ProbeAsync(endpoint, ct);
+
     public async Task<TalkStartResult> StartAsync(BackchannelEndpoint endpoint, CancellationToken ct)
     {
         if (!_input.IsAvailable) return TalkStartResult.Failed;

--- a/src/OpenIPC.Viewer.Devices/Backchannel/RtspBackchannelClient.cs
+++ b/src/OpenIPC.Viewer.Devices/Backchannel/RtspBackchannelClient.cs
@@ -97,6 +97,35 @@ public sealed class RtspBackchannelClient : IAudioBackchannelClient
         }
     }
 
+    public async Task<bool> ProbeAsync(BackchannelEndpoint endpoint, CancellationToken ct)
+    {
+        var uri = endpoint.RtspUri;
+        var host = uri.Host;
+        var port = uri.Port > 0 ? uri.Port : 554;
+        var baseUrl = StripUserInfo(uri);
+
+        var tcp = new TcpClient { NoDelay = true };
+        try
+        {
+            await tcp.ConnectAsync(host, port, ct).ConfigureAwait(false);
+            var session = new Session(tcp, tcp.GetStream(), _logger);
+            var auth = new DigestState(endpoint.Credentials);
+            var cseq = 0;
+
+            await session.RequestAsync("OPTIONS", baseUrl, ++cseq, auth, null, ct).ConfigureAwait(false);
+            var describe = await session.RequestAsync("DESCRIBE", baseUrl, ++cseq, auth,
+                new[] { ("Accept", "application/sdp"), ("Require", BackchannelRequire) }, ct).ConfigureAwait(false);
+            if (describe.Status != 200)
+                throw new InvalidOperationException($"DESCRIBE failed: {describe.Status}");
+
+            return SdpParser.FindBackchannelAudio(describe.Body) is not null;
+        }
+        finally
+        {
+            tcp.Dispose();
+        }
+    }
+
     private static string StripUserInfo(Uri uri)
     {
         var b = new UriBuilder(uri) { UserName = "", Password = "" };

--- a/src/OpenIPC.Viewer.Devices/Majestic/MajesticHttpClient.cs
+++ b/src/OpenIPC.Viewer.Devices/Majestic/MajesticHttpClient.cs
@@ -38,15 +38,38 @@ public sealed class MajesticHttpClient : IMajesticClient, IDisposable
     {
         try
         {
-            using var resp = await SendAsync(endpoint, HttpMethod.Get, "api/v1/info.json", ct).ConfigureAwait(false);
+            // Probe config.json, not info.json: some firmwares don't serve
+            // info.json and fall back to the web UI's HTML index (200 OK,
+            // "<!DOCTYPE html>"), which fails the JSON sniff and hides an
+            // otherwise working Majestic. config.json is the canonical endpoint
+            // and always returns the live config object.
+            using var resp = await SendAsync(endpoint, HttpMethod.Get, "api/v1/config.json", ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode) return false;
             var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
-            // Cheap content-shape sniff: not JSON → not Majestic.
-            return body.TrimStart().StartsWith('{');
+            return LooksLikeMajesticConfig(body);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Majestic ping failed for {Host}", endpoint.Host);
+            return false;
+        }
+    }
+
+    // A Majestic config root always carries these top-level sections; checking
+    // for one avoids treating an unrelated JSON endpoint as a Majestic camera.
+    private static bool LooksLikeMajesticConfig(string body)
+    {
+        if (!body.TrimStart().StartsWith('{')) return false;
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return false;
+            return doc.RootElement.TryGetProperty("system", out _)
+                || doc.RootElement.TryGetProperty("video0", out _)
+                || doc.RootElement.TryGetProperty("rtsp", out _);
+        }
+        catch (JsonException)
+        {
             return false;
         }
     }
@@ -64,14 +87,32 @@ public sealed class MajesticHttpClient : IMajesticClient, IDisposable
     {
         using var resp = await SendAsync(endpoint, HttpMethod.Get, "api/v1/info.json", ct).ConfigureAwait(false);
         await EnsureSuccessAsync(resp, ct).ConfigureAwait(false);
-        await using var stream = await resp.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-        using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-        var root = doc.RootElement;
-        return new MajesticInfo(
-            Model: TryGetString(root, "model"),
-            FirmwareVersion: TryGetString(root, "firmware") ?? TryGetString(root, "build"),
-            ChipModel: TryGetString(root, "chip") ?? TryGetString(root, "soc"),
-            Uptime: TryGetString(root, "uptime"));
+        var rawJson = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        // Some firmwares don't serve info.json and return the web UI's HTML
+        // index with 200 OK. Treat a non-JSON body as "no info available"
+        // rather than letting the parse error abort the whole state load —
+        // info is optional metadata (model/firmware), config.json is the part
+        // that matters.
+        if (!rawJson.TrimStart().StartsWith('{'))
+        {
+            _logger.LogDebug("Majestic info.json for {Host} was not JSON; skipping", endpoint.Host);
+            return new MajesticInfo(null, null, null, null);
+        }
+        try
+        {
+            using var doc = JsonDocument.Parse(rawJson);
+            var root = doc.RootElement;
+            return new MajesticInfo(
+                Model: TryGetString(root, "model"),
+                FirmwareVersion: TryGetString(root, "firmware") ?? TryGetString(root, "build"),
+                ChipModel: TryGetString(root, "chip") ?? TryGetString(root, "soc"),
+                Uptime: TryGetString(root, "uptime"));
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug(ex, "Majestic info.json parse failed for {Host}", endpoint.Host);
+            return new MajesticInfo(null, null, null, null);
+        }
     }
 
     public async Task UpdateConfigAsync(MajesticEndpoint endpoint, MajesticConfigPatch patch, CancellationToken ct)

--- a/src/OpenIPC.Viewer.Devices/Onvif/OnvifClientBuilder.cs
+++ b/src/OpenIPC.Viewer.Devices/Onvif/OnvifClientBuilder.cs
@@ -97,13 +97,15 @@ internal static class OnvifClientBuilder
         {
             shift = await probe.GetDeviceTimeShift().ConfigureAwait(false);
         }
-        catch (CommunicationException)
+        catch (Exception ex) when (ex is CommunicationException or TimeoutException)
         {
             // Some firmwares answer GetSystemDateAndTime with an empty/truncated
-            // body ("Unexpected end of file"), which used to abort the whole add
-            // flow. The shift only compensates camera clock skew for the
-            // WS-UsernameToken digest — assume zero and proceed; if the camera
-            // truly rejects the digest, the next call surfaces the real error.
+            // body ("Unexpected end of file") or accept the request and never
+            // reply (broken onvif_simple_server → TimeoutException), which used
+            // to abort the whole add flow. The shift only compensates camera
+            // clock skew for the WS-UsernameToken digest — assume zero and
+            // proceed; if the camera truly rejects the digest, the next call
+            // surfaces the real error.
             shift = TimeSpan.Zero;
         }
         finally
@@ -149,7 +151,18 @@ internal static class OnvifClientBuilder
 
     private static Binding CreateBinding()
     {
-        var binding = new CustomBinding();
+        var binding = new CustomBinding
+        {
+            // WCF defaults every timeout to 1 minute. A camera with a broken
+            // onvif_simple_server (accepts the authed request, then never
+            // answers) would otherwise hang the probe/add flow for the full
+            // minute per call. Fail fast so the UI can fall back to RTSP/Majestic
+            // instead of freezing.
+            SendTimeout = TimeSpan.FromSeconds(8),
+            ReceiveTimeout = TimeSpan.FromSeconds(8),
+            OpenTimeout = TimeSpan.FromSeconds(8),
+            CloseTimeout = TimeSpan.FromSeconds(5),
+        };
         binding.Elements.Add(new TextMessageEncodingBindingElement
         {
             MessageVersion = MessageVersion.CreateVersion(EnvelopeVersion.Soap12, AddressingVersion.None),

--- a/src/OpenIPC.Viewer.Video/FfmpegVideoEngine.cs
+++ b/src/OpenIPC.Viewer.Video/FfmpegVideoEngine.cs
@@ -13,6 +13,16 @@ public sealed class FfmpegVideoEngine : IVideoEngine, IPlaybackEngine
     {
         _loggerFactory = loggerFactory;
         _hwFactory = hwFactory;
+
+        // Route FFmpeg's native log lines into our logger. Singleton, so this
+        // subscribes exactly once for the app's lifetime.
+        var nativeLog = loggerFactory.CreateLogger("FFmpeg.Native");
+        FfmpegRuntime.NativeLog += (level, message) =>
+        {
+            // AV_LOG_ERROR=16, AV_LOG_WARNING=24 — lower is more severe.
+            if (level <= 16) nativeLog.LogWarning("{Message}", message);
+            else nativeLog.LogInformation("{Message}", message);
+        };
     }
 
     public IVideoSession CreateSession(VideoSessionOptions options)

--- a/src/OpenIPC.Viewer.Video/Pipeline/FfmpegError.cs
+++ b/src/OpenIPC.Viewer.Video/Pipeline/FfmpegError.cs
@@ -25,8 +25,18 @@ internal sealed class FfmpegException : Exception
     public int Code { get; }
 
     public FfmpegException(string operation, int code)
-        : base($"{operation} failed: {FfmpegError.Describe(code)} ({code})")
+        : base(Compose(operation, code))
     {
         Code = code;
+    }
+
+    // Append FFmpeg's own last error line when we captured one — turns a generic
+    // "Operation not permitted (-1)" into the concrete cause (e.g. a 401 or
+    // "Connection refused") surfaced in the UI error banner.
+    private static string Compose(string operation, int code)
+    {
+        var msg = $"{operation} failed: {FfmpegError.Describe(code)} ({code})";
+        var native = FfmpegRuntime.TakeLastNativeError();
+        return string.IsNullOrEmpty(native) ? msg : $"{msg} — {native}";
     }
 }

--- a/src/OpenIPC.Viewer.Video/Pipeline/FfmpegRuntime.cs
+++ b/src/OpenIPC.Viewer.Video/Pipeline/FfmpegRuntime.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using FFmpeg.AutoGen.Abstractions;
 using FFmpeg.AutoGen.Bindings.DynamicallyLoaded;
@@ -8,6 +9,26 @@ namespace OpenIPC.Viewer.Video.Pipeline;
 
 internal static class FfmpegRuntime
 {
+    // Raised for every native FFmpeg log line at warning level or worse. The
+    // video engine subscribes once and routes these to ILogger; nobody else
+    // should. Kept as a plain event so the Video project stays DI-free here.
+    public static event Action<int, string>? NativeLog;
+
+    // The real reason behind the most recent error, captured off FFmpeg's own
+    // log (av_strerror only gives the generic "Operation not permitted"). Thread
+    // -static because avformat_open_input logs synchronously on its caller; the
+    // FfmpegException ctor on that same thread consumes it.
+    [ThreadStatic] private static string? _lastNativeError;
+
+    // Held so the GC can't collect the delegate while native code holds it.
+    private static av_log_set_callback_callback? _logCallback;
+
+    internal static string? TakeLastNativeError()
+    {
+        var v = _lastNativeError;
+        _lastNativeError = null;
+        return v;
+    }
     // Serializes the one-time native init. The old design used an Interlocked
     // CompareExchange flag, but that let the *second* caller return "ready"
     // the instant the first caller flipped the flag — before its (slow)
@@ -64,6 +85,7 @@ internal static class FfmpegRuntime
                 // libs early — anything missing surfaces here instead of mid-stream.
                 _ = ffmpeg.av_version_info();
                 ffmpeg.avformat_network_init();
+                InstallLogCallback();
             }
             catch (Exception ex) when (IsNativeLoadFailure(ex))
             {
@@ -89,6 +111,34 @@ internal static class FfmpegRuntime
 
             _ready = true;
         }
+    }
+
+    // Route FFmpeg's internal av_log through a managed callback so the actual
+    // failure reason (auth 401, connection refused, protocol whitelist, ...) is
+    // captured instead of just the strerror of the return code.
+    private static unsafe void InstallLogCallback()
+    {
+        _logCallback = LogCallback;
+        ffmpeg.av_log_set_level(ffmpeg.AV_LOG_WARNING);
+        ffmpeg.av_log_set_callback(_logCallback);
+    }
+
+    private static unsafe void LogCallback(void* avcl, int level, string fmt, byte* vl)
+    {
+        if (level > ffmpeg.AV_LOG_WARNING) return;
+
+        const int bufSize = 1024;
+        var buf = stackalloc byte[bufSize];
+        var printPrefix = 1;
+        ffmpeg.av_log_format_line2(avcl, level, fmt, vl, buf, bufSize, &printPrefix);
+        var msg = Marshal.PtrToStringAnsi((IntPtr)buf)?.Trim();
+        if (string.IsNullOrEmpty(msg)) return;
+
+        if (level <= ffmpeg.AV_LOG_ERROR) _lastNativeError = msg;
+
+        // A logging sink must never throw back into native FFmpeg.
+        try { NativeLog?.Invoke(level, msg); }
+        catch { /* swallow */ }
     }
 
     private static bool IsNativeLoadFailure(Exception ex)

--- a/tests/OpenIPC.Viewer.Core.Tests/Audio/PushToTalkControllerTests.cs
+++ b/tests/OpenIPC.Viewer.Core.Tests/Audio/PushToTalkControllerTests.cs
@@ -102,6 +102,8 @@ public class PushToTalkControllerTests
         public FakeClient(FakeSession? session) => _session = session;
         public Task<IAudioBackchannelSession?> OpenAsync(BackchannelEndpoint endpoint, CancellationToken ct)
             => Task.FromResult<IAudioBackchannelSession?>(_session);
+        public Task<bool> ProbeAsync(BackchannelEndpoint endpoint, CancellationToken ct)
+            => Task.FromResult(_session is not null);
     }
 
     private sealed class FakeSession : IAudioBackchannelSession

--- a/tools/build-ffmpeg-android.sh
+++ b/tools/build-ffmpeg-android.sh
@@ -136,8 +136,8 @@ build_one() {
         --enable-network \
         --enable-protocol=file,http,https,tcp,udp,rtp,rtsp,tls \
         --enable-demuxer=rtsp,rtp,sdp,mpegts,mov,h264,hevc \
-        --enable-parser=h264,hevc,aac \
-        --enable-decoder=h264,h264_mediacodec,hevc,hevc_mediacodec,aac \
+        --enable-parser=h264,hevc,aac,opus \
+        --enable-decoder=h264,h264_mediacodec,hevc,hevc_mediacodec,aac,opus,pcm_mulaw,pcm_alaw \
         --enable-bsf=h264_mp4toannexb,hevc_mp4toannexb,extract_extradata \
         --enable-muxer=mp4 \
         --enable-encoder=h264_mediacodec,hevc_mediacodec


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- Majestic: detect via config.json (info.json is the web UI's HTML on some
  firmwares) and tolerate a non-JSON info.json instead of throwing
- ONVIF: 8s WCF binding timeouts + catch TimeoutException so a broken
  onvif_simple_server fails fast rather than hanging the probe for 60s
- Android: enable opus/pcm_mulaw/pcm_alaw FFmpeg decoders so camera audio
  plays on the phone (requires rebuilding the native libs)
- Grid: Back from a camera returns to the originating page (grid vs library)
- Desktop: persist and restore main window position/size/maximized state
- Grid: add 4x4 and 5x5 layouts (up to 25 tiles)
- Video: route FFmpeg native av_log to ILogger and append the real cause
  (401, connection refused, ...) to FfmpegException messages
- Analytics: map detection boxes into the letterboxed video rect via CameraTileViewModel.SourceAspect
- ShowRawConfigEditorAsync takes a validateJson flag; the Edit-over-SSH path passes false so Apply no longer rejects majestic.yaml as "invalid JSON" and silently refuses to save
- drop JSON syntax highlighting when editing YAML
- IAudioBackchannelClient.ProbeAsync: lightweight OPTIONS+DESCRIBE capability check (no SETUP/PLAY); RtspBackchannelClient implements it
- camera page probes the backchannel once on activation and shows a hint when the camera advertises none, instead of a silently disappearing talk button

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
