### PR TITLE
fix: process no longer hangs after window close

### DIFF
--- a/src/OpenIPC.Viewer.Desktop/Program.cs
+++ b/src/OpenIPC.Viewer.Desktop/Program.cs
@@ -46,7 +46,21 @@ internal static class Program
             // ServiceProvider.Dispose throws on services that only implement
             // IAsyncDisposable (LiveStreamCoordinator, GridPageViewModel, etc.).
             // DisposeAsync handles both shapes.
-            services.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            //
+            // We're back on the UI thread here, but the dispatcher loop has already
+            // exited. Disposing inline would deadlock: service DisposeAsync paths
+            // use ConfigureAwait(true) (e.g. GridPageViewModel releasing live grid
+            // tiles), and their continuations would post to the now-dead dispatcher
+            // and never run — leaving the process hung in the background. Dispose on
+            // a thread-pool thread instead (no SynchronizationContext to capture, so
+            // those continuations resume freely), and bound the wait so a wedged
+            // native join can't keep us alive either — background threads die with
+            // the process regardless.
+            if (!System.Threading.Tasks.Task.Run(() => services.DisposeAsync().AsTask())
+                    .Wait(TimeSpan.FromSeconds(10)))
+            {
+                logger.LogWarning("Service disposal timed out during shutdown; forcing exit");
+            }
         }
     }
 


### PR DESCRIPTION
- dispose services on a thread-pool thread, not the dead UI thread
- avoids deadlock: ConfigureAwait(true) continuations (live grid tiles) posted to the stopped Avalonia dispatcher and never resumed
- bound disposal to 10s so a wedged native join can't hold the process

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary
#33 
<!-- What does this PR do and why? -->

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
