### PR TITLE
feat: idle stream auto-pause to spare the camera network

### DIFF
--- a/src/OpenIPC.Viewer.App/Services/IdleStreamMonitor.cs
+++ b/src/OpenIPC.Viewer.App/Services/IdleStreamMonitor.cs
@@ -1,0 +1,91 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.Messaging;
+using OpenIPC.Viewer.App.Messages;
+
+namespace OpenIPC.Viewer.App.Services;
+
+// Foreground idle watchdog (opt-in). When the user leaves the app open but
+// stops interacting for UserSettings.IdleStreamTimeoutMinutes, release the live
+// streams to spare the camera network — the "left it open and walked away" case
+// that minimize-detection never sees. It reuses the very same Window
+// minimize/restore messages the grid already acts on (Smart Pause → release →
+// rebuild), so no new teardown path is needed.
+//
+// Window minimize is owned by MainWindow; this parks itself while the window is
+// actually minimized so the two don't double up on the same release.
+public sealed class IdleStreamMonitor
+{
+    private readonly UserSettingsService _settings;
+    private readonly DispatcherTimer _timer;
+    private bool _suspended;
+    private bool _minimized;
+
+    public IdleStreamMonitor(UserSettingsService settings)
+    {
+        _settings = settings;
+        _timer = new DispatcherTimer();
+        _timer.Tick += (_, _) => OnTick();
+        _settings.Changed += (_, _) => Reset();
+    }
+
+    // Hook window-scoped input on the tunnel so a click that's handled by a
+    // child control still counts as activity. Window-scoped (not a global OS
+    // hook) is exactly right: when our window isn't focused it gets no input, so
+    // "another app in front" also counts as idle.
+    public void Attach(Window window)
+    {
+        window.AddHandler(InputElement.PointerMovedEvent, OnInput, RoutingStrategies.Tunnel);
+        window.AddHandler(InputElement.PointerPressedEvent, OnInput, RoutingStrategies.Tunnel);
+        window.AddHandler(InputElement.PointerWheelChangedEvent, OnInput, RoutingStrategies.Tunnel);
+        window.AddHandler(InputElement.KeyDownEvent, OnInput, RoutingStrategies.Tunnel);
+        Reset();
+    }
+
+    // MainWindow tells us when the OS minimize state flips so we step aside for
+    // the real minimize→release path and don't fire a duplicate.
+    public void SetMinimized(bool minimized)
+    {
+        _minimized = minimized;
+        if (minimized)
+        {
+            _timer.Stop();
+            _suspended = false;
+        }
+        else
+        {
+            Reset();
+        }
+    }
+
+    private void OnInput(object? sender, RoutedEventArgs e)
+    {
+        if (_suspended)
+        {
+            _suspended = false;
+            WeakReferenceMessenger.Default.Send(new WindowRestoredMessage());
+        }
+        Reset();
+    }
+
+    private void Reset()
+    {
+        _timer.Stop();
+        if (_minimized) return;
+        var minutes = _settings.Current.IdleStreamTimeoutMinutes;
+        if (minutes <= 0) return;
+        _timer.Interval = TimeSpan.FromMinutes(minutes);
+        _timer.Start();
+    }
+
+    private void OnTick()
+    {
+        _timer.Stop();
+        if (_suspended || _minimized) return;
+        _suspended = true;
+        WeakReferenceMessenger.Default.Send(new WindowMinimizedMessage());
+    }
+}

--- a/src/OpenIPC.Viewer.App/Services/Localizer.cs
+++ b/src/OpenIPC.Viewer.App/Services/Localizer.cs
@@ -198,6 +198,10 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Settings.Video.RtspTransport"] = "Default RTSP transport",
         ["Settings.Video.NetworkInterface"] = "Network interface (discovery)",
         ["Settings.Video.NetworkInterface.Auto"] = "Auto",
+        ["Settings.Video.IdleTimeout"] = "Pause streams after inactivity",
+        ["Settings.Video.IdleTimeout.Off"] = "Off",
+        ["Settings.Video.IdleTimeout.Minutes"] = "{0} min",
+        ["Settings.Video.IdleTimeout.Note"] = "When the window is left open and untouched for this long, all live streams stop to spare the camera network. Any input resumes them. Note: this also pauses motion/AI alerts while suspended.",
 
         ["Settings.Recording.Directory"] = "Recordings directory",
         ["Settings.Recording.PickFolder"] = "Pick folder…",
@@ -581,6 +585,10 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Settings.Video.RtspTransport"] = "RTSP-транспорт по умолчанию",
         ["Settings.Video.NetworkInterface"] = "Сетевой интерфейс (поиск)",
         ["Settings.Video.NetworkInterface.Auto"] = "Авто",
+        ["Settings.Video.IdleTimeout"] = "Останавливать потоки при простое",
+        ["Settings.Video.IdleTimeout.Off"] = "Выкл.",
+        ["Settings.Video.IdleTimeout.Minutes"] = "{0} мин",
+        ["Settings.Video.IdleTimeout.Note"] = "Если окно оставлено открытым и с ним не взаимодействуют это время, все живые потоки останавливаются, чтобы не грузить сеть камер. Любой ввод возобновляет их. Учтите: на время паузы также приостанавливаются уведомления о движении/ИИ-детекции.",
 
         ["Settings.Recording.Directory"] = "Папка записей",
         ["Settings.Recording.PickFolder"] = "Выбрать…",

--- a/src/OpenIPC.Viewer.App/Services/UserSettings.cs
+++ b/src/OpenIPC.Viewer.App/Services/UserSettings.cs
@@ -11,6 +11,12 @@ public sealed record UserSettings(
     bool AutoScanLanOnStartup = false,
     int MaxConcurrentGridSessions = 9,
     string RtspTransport = "tcp",
+    // Idle stream auto-pause (opt-in). Minutes of no user input while the window
+    // is open before all live sessions are released to spare the camera network;
+    // 0 = off. Window minimize already pauses+releases regardless of this (see
+    // GridPageViewModel.Receive(WindowMinimizedMessage)) — this covers the
+    // "left open in the foreground and walked away" case.
+    int IdleStreamTimeoutMinutes = 0,
     // Auto SD/HD (Phase 12.2): substream in the multi-camera grid, mainstream
     // when a single tile fills the view (1×1 layout / single-camera page).
     // Off → always substream in the grid.

--- a/src/OpenIPC.Viewer.App/ViewModels/SettingsPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/SettingsPageViewModel.cs
@@ -35,6 +35,9 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
     [ObservableProperty] private string _rtspTransport = "tcp";
     [ObservableProperty] private bool _autoSdHd = true;
 
+    // Idle stream auto-pause (opt-in). Selected option carries the minutes; 0 = off.
+    [ObservableProperty] private IdleTimeoutOption? _idleTimeout;
+
     // AI analytics (Phase 15.2). On → pin the CPU execution provider.
     [ObservableProperty] private bool _aiForceCpu;
 
@@ -120,6 +123,10 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
 
     public int[] GridSessionOptions { get; } = new[] { 4, 9, 16, 25 };
     public string[] TransportOptions { get; } = new[] { "tcp", "udp" };
+
+    // Off + a few sensible idle thresholds (minutes). Built with localized labels
+    // in the constructor so "Off"/"N min" follow the active language.
+    public IReadOnlyList<IdleTimeoutOption> IdleTimeoutOptions { get; }
     public string[] LanguageOptions { get; } = new[] { "system", "en", "ru" };
 
     // Auto + each usable LAN adapter (Phase 12.6). Display shown in the combo,
@@ -159,6 +166,14 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
         options.AddRange(nics.GetCandidates().Select(c => new NetworkInterfaceOption(c.DisplayName, c.Address)));
         NetworkInterfaceOptions = options;
 
+        IdleTimeoutOptions = new[] { 0, 5, 10, 15, 30, 60 }
+            .Select(m => new IdleTimeoutOption(
+                m == 0
+                    ? Localizer.Instance["Settings.Video.IdleTimeout.Off"]
+                    : string.Format(CultureInfo.CurrentCulture, Localizer.Instance["Settings.Video.IdleTimeout.Minutes"], m),
+                m))
+            .ToList();
+
         Load();
     }
 
@@ -178,6 +193,8 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
             MaxConcurrentGridSessions = s.MaxConcurrentGridSessions;
             RtspTransport = s.RtspTransport;
             AutoSdHd = s.AutoSdHd;
+            IdleTimeout = IdleTimeoutOptions.FirstOrDefault(o => o.Minutes == s.IdleStreamTimeoutMinutes)
+                ?? IdleTimeoutOptions[0];
             AiForceCpu = string.Equals(s.AiAcceleration, "force-cpu", StringComparison.OrdinalIgnoreCase);
             SelectedNetworkInterface =
                 NetworkInterfaceOptions.FirstOrDefault(o => o.Value == s.PreferredNetworkInterface)
@@ -206,6 +223,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
     partial void OnMaxConcurrentGridSessionsChanged(int value) => Persist();
     partial void OnRtspTransportChanged(string value) => Persist();
     partial void OnAutoSdHdChanged(bool value) => Persist();
+    partial void OnIdleTimeoutChanged(IdleTimeoutOption? value) => Persist();
     partial void OnAiForceCpuChanged(bool value) => Persist();
     partial void OnSelectedNetworkInterfaceChanged(NetworkInterfaceOption? value) => Persist();
     partial void OnRecordingsDirOverrideChanged(string value) => Persist();
@@ -234,6 +252,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
             MaxConcurrentGridSessions = MaxConcurrentGridSessions,
             RtspTransport = RtspTransport,
             AutoSdHd = AutoSdHd,
+            IdleStreamTimeoutMinutes = IdleTimeout?.Minutes ?? 0,
             AiAcceleration = AiForceCpu ? "force-cpu" : "auto",
             PreferredNetworkInterface = SelectedNetworkInterface?.Value ?? "",
             RecordingsDirOverride = RecordingsDirOverride,
@@ -387,3 +406,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
 // Display is the human label ("Auto" / "Ethernet (192.168.1.5)"); Value is the
 // persisted IPv4 ("" = auto).
 public sealed record NetworkInterfaceOption(string Display, string Value);
+
+// Combo item for Settings → Video idle-pause picker. Display is the localized
+// label ("Off" / "10 min"); Minutes is the persisted threshold (0 = off).
+public sealed record IdleTimeoutOption(string Display, int Minutes);

--- a/src/OpenIPC.Viewer.App/Views/MainWindow.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/MainWindow.axaml.cs
@@ -12,6 +12,7 @@ namespace OpenIPC.Viewer.App.Views;
 public sealed partial class MainWindow : Window
 {
     private readonly UserSettingsService? _settings;
+    private readonly IdleStreamMonitor? _idle;
     private WindowState _previousState = WindowState.Normal;
 
     // Last known normal-state geometry, tracked live so a window that closes
@@ -25,6 +26,12 @@ public sealed partial class MainWindow : Window
 
         _settings = App.Services?.GetService<UserSettingsService>();
         RestoreGeometry();
+
+        if (_settings is not null)
+        {
+            _idle = new IdleStreamMonitor(_settings);
+            _idle.Attach(this);
+        }
 
         PropertyChanged += OnWindowPropertyChanged;
         PositionChanged += (_, _) => CaptureNormalBounds();
@@ -131,9 +138,15 @@ public sealed partial class MainWindow : Window
 
         var current = (WindowState)e.NewValue!;
         if (current == WindowState.Minimized && _previousState != WindowState.Minimized)
+        {
+            _idle?.SetMinimized(true);
             WeakReferenceMessenger.Default.Send(new WindowMinimizedMessage());
+        }
         else if (_previousState == WindowState.Minimized && current != WindowState.Minimized)
+        {
+            _idle?.SetMinimized(false);
             WeakReferenceMessenger.Default.Send(new WindowRestoredMessage());
+        }
 
         _previousState = current;
     }

--- a/src/OpenIPC.Viewer.App/Views/Pages/SettingsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SettingsPage.axaml
@@ -280,6 +280,22 @@
                       DisplayMemberBinding="{Binding Display}"
                       MinWidth="160" />
           </Grid>
+
+          <StackPanel Spacing="6">
+            <Grid ColumnDefinitions="*,Auto">
+              <TextBlock Grid.Column="0" Classes="field-label"
+                         Text="{Binding [Settings.Video.IdleTimeout], Source={x:Static svc:Localizer.Instance}}" />
+              <ComboBox Grid.Column="1"
+                        ItemsSource="{Binding IdleTimeoutOptions}"
+                        SelectedItem="{Binding IdleTimeout, Mode=TwoWay}"
+                        DisplayMemberBinding="{Binding Display}"
+                        MinWidth="120" />
+            </Grid>
+            <TextBlock Classes="field-label"
+                       FontSize="{StaticResource FontSizeSm}"
+                       Foreground="{StaticResource TextTertiaryBrush}"
+                       Text="{Binding [Settings.Video.IdleTimeout.Note], Source={x:Static svc:Localizer.Instance}}" />
+          </StackPanel>
         </StackPanel>
 
         <!-- Recording -->
@@ -403,6 +419,26 @@
                        TextWrapping="Wrap" />
           </StackPanel>
 
+          <!-- Config export / import (Phase 19.2) -->
+          <Border Background="{StaticResource BorderWeakBrush}" Height="1" Margin="0,8" />
+          <TextBlock Classes="section-title"
+                     Text="{Binding [Settings.Backup.Section], Source={x:Static svc:Localizer.Instance}}" />
+          <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
+                     TextWrapping="Wrap"
+                     Text="{Binding [Settings.Backup.Description], Source={x:Static svc:Localizer.Instance}}" />
+          <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
+            <Button Classes="outlined"
+                    Content="{Binding [Settings.Backup.Export], Source={x:Static svc:Localizer.Instance}}"
+                    Command="{Binding ExportConfigCommand}" />
+            <Button Classes="outlined"
+                    Content="{Binding [Settings.Backup.Import], Source={x:Static svc:Localizer.Instance}}"
+                    Command="{Binding ImportConfigCommand}" />
+          </WrapPanel>
+          <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
+                     FontSize="{StaticResource FontSizeSm}"
+                     Text="{Binding BackupStatus}"
+                     IsVisible="{Binding BackupStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
           <!-- Notifications (Phase 19.3) -->
           <Border Background="{StaticResource BorderWeakBrush}" Height="1" Margin="0,8" />
           <TextBlock Classes="section-title"
@@ -466,26 +502,6 @@
                     Content="{Binding [Settings.Report.OpenLogs], Source={x:Static svc:Localizer.Instance}}"
                     Command="{Binding OpenLogsDirectoryCommand}" />
           </WrapPanel>
-
-          <!-- Config export / import (Phase 19.2) -->
-          <Border Background="{StaticResource BorderWeakBrush}" Height="1" Margin="0,8" />
-          <TextBlock Classes="section-title"
-                     Text="{Binding [Settings.Backup.Section], Source={x:Static svc:Localizer.Instance}}" />
-          <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
-                     TextWrapping="Wrap"
-                     Text="{Binding [Settings.Backup.Description], Source={x:Static svc:Localizer.Instance}}" />
-          <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
-            <Button Classes="outlined"
-                    Content="{Binding [Settings.Backup.Export], Source={x:Static svc:Localizer.Instance}}"
-                    Command="{Binding ExportConfigCommand}" />
-            <Button Classes="outlined"
-                    Content="{Binding [Settings.Backup.Import], Source={x:Static svc:Localizer.Instance}}"
-                    Command="{Binding ImportConfigCommand}" />
-          </WrapPanel>
-          <TextBlock Foreground="{StaticResource TextSecondaryBrush}"
-                     FontSize="{StaticResource FontSizeSm}"
-                     Text="{Binding BackupStatus}"
-                     IsVisible="{Binding BackupStatus, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
         </StackPanel>
 
       </StackPanel>


### PR DESCRIPTION
- add opt-in "pause streams after inactivity" setting (Settings > Video, off by default)
- IdleStreamMonitor reuses the window minimize/restore path to release RTSP after N idle minutes
- move config export/import from About to Advanced section

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

<!-- What does this PR do and why? -->
#32 

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
