### PR TITLE
fix: bundle FFmpeg 7 .so in linux-x64 release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must stay LF — CRLF breaks the shebang/parsing when run on
+# Linux (CI fetch-ffmpeg-linux.sh, build-ffmpeg-android.sh) even though the
+# repo is checked out on Windows.
+*.sh text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,18 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
-      - name: Install ffmpeg + libsecret (Linux)
+      # libsecret for the keyring; the bundled FFmpeg 7 .so come from the fetch
+      # step below, not apt — the distro ffmpeg (6.1 on 24.04 runners) is the
+      # wrong ABI for FFmpeg.AutoGen 7.1.1 and must NOT end up in the archive.
+      - name: Install libsecret (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg libavcodec-extra libsecret-1-0 libsecret-tools
+          sudo apt-get install -y libsecret-1-0 libsecret-tools
+
+      - name: Fetch bundled ffmpeg (Linux)
+        if: runner.os == 'Linux'
+        run: bash ./tools/fetch-ffmpeg-linux.sh
 
       - name: Install ffmpeg (macOS)
         if: runner.os == 'macOS'

--- a/README.md
+++ b/README.md
@@ -68,13 +68,19 @@ a later release.
 ### Runtime requirements
 
 - **Windows** — none. FFmpeg DLLs ship inside the archive.
-- **Linux** — system FFmpeg + libsecret:
+- **Linux** — just libsecret for the keyring:
   ```
-  sudo apt install ffmpeg libavcodec-extra libsecret-1-0 libsecret-tools
+  sudo apt install libsecret-1-0 libsecret-tools
   ```
-  VAAPI hardware decode needs `/dev/dri/renderD128` and your user in the
-  `render` (or `video`) group. Credentials use `secret-tool` against the
-  GNOME/KDE keyring, with an AES-GCM file fallback if D-Bus is unavailable.
+  FFmpeg ships **inside the archive** (matching `n7.1` `.so`) — do *not* rely on
+  `apt install ffmpeg`. The app binds the FFmpeg 7.x ABI (`libavcodec.so.61`),
+  but no current Ubuntu LTS packages FFmpeg 7 (24.04 has 6.1 → `libavcodec.so.60`,
+  22.04 has 4.4), so a system FFmpeg would fail to load with *"FFmpeg native
+  libraries failed to load for runtime linux-x64"*. The bundled libs sidestep
+  the distro version entirely. VAAPI hardware decode still needs
+  `/dev/dri/renderD128` and your user in the `render` (or `video`) group.
+  Credentials use `secret-tool` against the GNOME/KDE keyring, with an AES-GCM
+  file fallback if D-Bus is unavailable.
 - **macOS** — Homebrew FFmpeg (`brew install ffmpeg`). VideoToolbox HW decode
   works on any Mac 12+. Credentials live in the Keychain via `security`.
 
@@ -93,9 +99,10 @@ dotnet run --project src/OpenIPC.Viewer.Desktop
 ```
 
 Build runs with `TreatWarningsAsErrors=true`; any warning fails the build.
-On Windows, run `tools/fetch-ffmpeg.ps1` once to download the bundled FFmpeg
-shared-build DLLs (`n7.1` ABI) from `BtbN/FFmpeg-Builds` into
-`runtimes/win-x64/native/`. Linux / macOS use the system FFmpeg (see
+Run the FFmpeg fetch script for your OS once — it downloads the bundled
+shared-build (`n7.1` ABI) from `BtbN/FFmpeg-Builds` into `runtimes/<rid>/native/`:
+`tools/fetch-ffmpeg.ps1` (Windows → `win-x64`) or `tools/fetch-ffmpeg-linux.sh`
+(Linux → `linux-x64`). macOS uses the system Homebrew FFmpeg (see
 [Runtime requirements](#runtime-requirements)).
 
 ### Android

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,17 @@ powershell -ExecutionPolicy Bypass -File tools/fetch-ffmpeg.ps1
 
 ## Linux
 
+**`FFmpeg native libraries failed to load for runtime linux-x64`.** The app
+needs the FFmpeg **7.x** ABI (`libavcodec.so.61`), but no current Ubuntu LTS
+ships FFmpeg 7 — 24.04 has 6.1 (`libavcodec.so.60`), 22.04 has 4.4 — so
+`apt install ffmpeg` cannot satisfy it no matter how many `libav*` packages are
+installed. The release archive **bundles** matching `n7.1` `.so`, so the fix is
+to run the *extracted* `./OpenIPC.Viewer.Desktop` with its `runtimes/` folder
+intact next to it (don't move the binary out on its own). Building from source?
+Run `tools/fetch-ffmpeg-linux.sh` once to populate `runtimes/linux-x64/native/`.
+To confirm what your system has: `ffmpeg -version | head -1` — anything below 7
+is the wrong ABI and is ignored in favour of the bundled libs.
+
 **VAAPI: `/dev/dri/renderD128` not found.** No GPU exposed to the user
 session, or no DRI driver loaded. The app falls back to software decode;
 that works but uses much more CPU. To enable VAAPI:

--- a/src/OpenIPC.Viewer.Video/Pipeline/FfmpegRuntime.cs
+++ b/src/OpenIPC.Viewer.Video/Pipeline/FfmpegRuntime.cs
@@ -103,7 +103,9 @@ internal static class FfmpegRuntime
                     $"Android: ensure runtimes/android-{{arm64,x64}}/native/*.so are populated " +
                     $"(run tools/build-ffmpeg-android.sh via WSL or pull .so from a CI APK artifact). " +
                     $"Desktop: keep the runtimes/ folder from the release archive next to the exe, " +
-                    $"or tools/fetch-ffmpeg.ps1 (Windows) / apt/brew. " +
+                    $"or run tools/fetch-ffmpeg.ps1 (Windows) / tools/fetch-ffmpeg-linux.sh (Linux) / " +
+                    $"brew install ffmpeg (macOS). NOTE: the app needs FFmpeg 7.x (libavcodec.so.61); " +
+                    $"distro packages like Ubuntu 24.04's are FFmpeg 6.1 (libavcodec.so.60) and will not load. " +
                     $"Underlying: {DescribeChain(ex)}", ex);
                 _ready = true;
                 throw _initFailure;

--- a/src/OpenIPC.Viewer.Video/Recording/FfmpegRecordingSession.cs
+++ b/src/OpenIPC.Viewer.Video/Recording/FfmpegRecordingSession.cs
@@ -55,6 +55,21 @@ internal sealed partial class FfmpegRecordingSession : IRecordingSession
             UseShellExecute = false,
             CreateNoWindow = true,
         };
+        // When the bundled (rooted) ffmpeg is used, its .so siblings live in the
+        // same runtimes/linux-x64/native dir — the BtbN binary's RUNPATH points
+        // at ../lib, which doesn't exist once co-located, so point the loader at
+        // the binary's own dir. A bare "ffmpeg" PATH lookup (system install)
+        // leaves the env untouched and finds its libs the normal way.
+        if (OperatingSystem.IsLinux() && Path.IsPathRooted(_ffmpegPath))
+        {
+            var binDir = Path.GetDirectoryName(_ffmpegPath);
+            if (!string.IsNullOrEmpty(binDir))
+            {
+                var existing = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH");
+                psi.Environment["LD_LIBRARY_PATH"] =
+                    string.IsNullOrEmpty(existing) ? binDir : $"{binDir}:{existing}";
+            }
+        }
         psi.ArgumentList.Add("-hide_banner");
         // verbose (not warning): the segment muxer logs "Opening '<path>' for
         // writing" at AV_LOG_VERBOSE. We parse that line to learn each segment

--- a/src/OpenIPC.Viewer.Video/Recording/FfmpegSubprocessRecorder.cs
+++ b/src/OpenIPC.Viewer.Video/Recording/FfmpegSubprocessRecorder.cs
@@ -14,8 +14,8 @@ namespace OpenIPC.Viewer.Video.Recording;
 //
 // FFmpeg path resolution (first hit wins):
 //   1. Explicit override (constructor / appsettings "Recording:FfmpegPath")
-//   2. Per-RID bundled binary in runtimes/{rid}/native/ (Phase 8 fills these
-//      for linux-x64 / osx-x64 / osx-arm64; today only win-x64 has artifacts)
+//   2. Per-RID bundled binary in runtimes/{rid}/native/ (win-x64 via
+//      fetch-ffmpeg.ps1, linux-x64 via fetch-ffmpeg-linux.sh; osx still TODO)
 //   3. "ffmpeg" — falls through to OS PATH lookup (apt/brew/PATH on *nix)
 public sealed class FfmpegSubprocessRecorder : IRecorder
 {

--- a/tools/fetch-ffmpeg-linux.sh
+++ b/tools/fetch-ffmpeg-linux.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Downloads the FFmpeg shared build (LGPL) for Linux x64 and places its .so
+# libraries + the ffmpeg binary in runtimes/linux-x64/native/. The shared libs
+# are what FFmpeg.AutoGen's DynamicallyLoaded loader dlopen()s for live decode;
+# the binary is what the subprocess recorder/clip-exporter shell out to.
+# Everything is git-ignored — every dev (and CI) runs this once.
+#
+# WHY THIS EXISTS (issue #35): the app binds FFmpeg.AutoGen 7.1.1, generated
+# against the FFmpeg n7.x ABI, so the loader resolves version-suffixed sonames
+# (libavcodec.so.61, libavformat.so.61, libavutil.so.59, ...). No current Ubuntu
+# LTS ships FFmpeg 7 — 24.04 has 6.1 (libavcodec.so.60), 22.04 has 4.4 — so
+# `apt install ffmpeg` cannot satisfy the ABI and live view dies with
+# "FFmpeg native libraries failed to load for runtime linux-x64". Bundling the
+# matching n7.1 libs next to the binary makes the linux-x64 release self-
+# contained, exactly like fetch-ffmpeg.ps1 does for win-x64.
+#
+# Source:  BtbN/FFmpeg-Builds GitHub releases (https://github.com/BtbN/FFmpeg-Builds).
+# Pin:     n7.1 (matches FFmpeg.AutoGen 7.1.x bindings).
+# Flavor:  lgpl-shared (no GPL components; redistributable alongside the app as
+#          long as the .so remain shared + replaceable — see README "Licensing").
+set -euo pipefail
+
+FFMPEG_VERSION="${FFMPEG_VERSION:-n7.1}"
+ASSET_NAME="${ASSET_NAME:-ffmpeg-${FFMPEG_VERSION}-latest-linux64-lgpl-shared-7.1.tar.xz}"
+FORCE="${FORCE:-0}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+native_dir="$repo_root/runtimes/linux-x64/native"
+cache_dir="$repo_root/.cache/ffmpeg"
+archive_path="$cache_dir/$ASSET_NAME"
+extract_dir="$cache_dir/${ASSET_NAME%.tar.xz}"
+
+download_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$ASSET_NAME"
+
+mkdir -p "$native_dir" "$cache_dir"
+
+if [[ -f "$archive_path" && "$FORCE" != "1" ]]; then
+  echo "[fetch-ffmpeg-linux] using cached $archive_path"
+else
+  echo "[fetch-ffmpeg-linux] downloading $download_url"
+  curl -fL --retry 3 -o "$archive_path" "$download_url"
+fi
+
+rm -rf "$extract_dir"
+echo "[fetch-ffmpeg-linux] extracting"
+tar -xJf "$archive_path" -C "$cache_dir"
+
+src_lib="$(find "$extract_dir" -type d -name lib -print -quit)"
+src_bin="$(find "$extract_dir" -type d -name bin -print -quit)"
+if [[ -z "$src_lib" ]]; then
+  echo "[fetch-ffmpeg-linux] could not locate lib/ inside $extract_dir" >&2
+  exit 1
+fi
+
+# Required runtime libs only — the DynamicallyLoaded loader resolves these five
+# plus avdevice/avfilter (pulled in transitively). cp -P preserves the soname
+# symlinks (libavcodec.so -> libavcodec.so.61 -> libavcodec.so.61.x.x); the
+# loader needs the .so.61 name and the libs find each other via RUNPATH=$ORIGIN.
+echo "[fetch-ffmpeg-linux] copying .so from $src_lib to $native_dir"
+shopt -s nullglob
+for pattern in avcodec avformat avutil swscale swresample avdevice avfilter postproc; do
+  for f in "$src_lib"/lib${pattern}.so*; do
+    cp -Pf "$f" "$native_dir/"
+    echo "  $(basename "$f")"
+  done
+done
+shopt -u nullglob
+
+# ffmpeg binary — the subprocess recorder + clip-exporter shell out to it. The
+# recorder sets LD_LIBRARY_PATH to this dir so it finds the .so above (its build
+# -time RUNPATH points at ../lib, which won't exist once co-located here).
+if [[ -n "$src_bin" && -f "$src_bin/ffmpeg" ]]; then
+  cp -f "$src_bin/ffmpeg" "$native_dir/"
+  chmod +x "$native_dir/ffmpeg"
+  echo "  ffmpeg"
+else
+  echo "[fetch-ffmpeg-linux] ffmpeg binary not found — recording/export will fall back to system PATH" >&2
+fi
+
+so_count="$(find "$native_dir" -maxdepth 1 -name '*.so*' | wc -l | tr -d ' ')"
+echo "[fetch-ffmpeg-linux] done. $native_dir contains $so_count .so file(s) + ffmpeg."


### PR DESCRIPTION
- distro ffmpeg (Ubuntu 24.04 = 6.1, .so.60) is the wrong ABI for FFmpeg.AutoGen 7.1.1 (needs .so.61), so live decode failed to load (#35)
- add tools/fetch-ffmpeg-linux.sh (BtbN n7.1 lgpl-shared) + CI fetch step; no Ubuntu LTS ships FFmpeg 7, so apt could never satisfy it
- recorder sets LD_LIBRARY_PATH for the bundled ffmpeg binary
- fix README/troubleshooting/loader error message to state the FFmpeg 7 ABI

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

<!-- What does this PR do and why? -->

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
