### PR TITLE
feat(stills): grid-wide snapshot mode

### DIFF
--- a/src/OpenIPC.Viewer.App/Services/Localizer.cs
+++ b/src/OpenIPC.Viewer.App/Services/Localizer.cs
@@ -497,6 +497,7 @@ public sealed class Localizer : INotifyPropertyChanged
 
         ["Grid.EmptySlot"] = "no camera",
         ["Grid.Tooltip.Fullscreen"] = "Fullscreen grid (F11) — Esc to exit",
+        ["Grid.Tooltip.Stills"] = "Stills mode — periodic snapshots instead of live video",
         ["Tile.Snapshot"] = "Snapshot (HD)",
 
         ["Welcome.Language"] = "Language",
@@ -961,6 +962,7 @@ public sealed class Localizer : INotifyPropertyChanged
 
         ["Grid.EmptySlot"] = "нет камеры",
         ["Grid.Tooltip.Fullscreen"] = "Сетка на весь экран (F11) — Esc для выхода",
+        ["Grid.Tooltip.Stills"] = "Режим кадров — периодические снимки вместо живого видео",
         ["Tile.Snapshot"] = "Снимок (HD)",
 
         ["Welcome.Language"] = "Язык",

--- a/src/OpenIPC.Viewer.App/Services/UserSettings.cs
+++ b/src/OpenIPC.Viewer.App/Services/UserSettings.cs
@@ -80,7 +80,12 @@ public sealed record UserSettings(
     int? WindowY = null,
     double WindowWidth = 1200,
     double WindowHeight = 780,
-    bool WindowMaximized = false)
+    bool WindowMaximized = false,
+    // Grid "stills" mode: show periodic HTTP snapshots instead of a live RTSP
+    // session in every grid tile — far cheaper on CPU/bandwidth for big walls.
+    // Interval is seconds between grabs. A per-camera override lands later.
+    bool GridStillsMode = false,
+    int GridStillsIntervalSeconds = 10)
 {
     public static UserSettings Default => new();
 }

--- a/src/OpenIPC.Viewer.App/ViewModels/CameraTileViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/CameraTileViewModel.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -31,7 +33,20 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
     private readonly AudioMonitor _audio;
     private readonly IReachabilityProbe _reachability;
     private readonly CameraStatusRegistry _statusRegistry;
+    private readonly ISnapshotFrameSource _frameSource;
     private readonly ILogger<CameraTileViewModel> _logger;
+
+    // "Stills" mode: instead of a live RTSP session this tile shows a periodic
+    // HTTP snapshot (StillFrame), refreshed every _stillsIntervalSeconds. Set at
+    // construction from the grid setting; the tile is rebuilt when it changes.
+    private readonly bool _stillsMode;
+    private readonly int _stillsIntervalSeconds;
+    private CancellationTokenSource? _stillsCts;
+
+    [ObservableProperty] private Bitmap? _stillFrame;
+
+    // Drives the template: Image (stills) vs RtspVideoView (live).
+    public bool StillsMode => _stillsMode;
 
     // On a stream fault we TCP-probe the camera so the status policy can tell a
     // wedged-but-alive camera (Attention) from a truly unreachable one (Offline).
@@ -221,6 +236,9 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
         AudioMonitor audio,
         IReachabilityProbe reachability,
         CameraStatusRegistry statusRegistry,
+        ISnapshotFrameSource frameSource,
+        bool stillsMode,
+        int stillsIntervalSeconds,
         ILogger<CameraTileViewModel> logger)
     {
         Camera = camera;
@@ -233,6 +251,9 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
         _audio = audio;
         _reachability = reachability;
         _statusRegistry = statusRegistry;
+        _frameSource = frameSource;
+        _stillsMode = stillsMode;
+        _stillsIntervalSeconds = stillsIntervalSeconds;
         _logger = logger;
 
         _coordinator.Invalidated += OnCoordinatorInvalidated;
@@ -278,6 +299,13 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
     {
         if (_started) return;
         _started = true;
+
+        // Stills mode: no decoder, just poll an HTTP snapshot on an interval.
+        if (_stillsMode)
+        {
+            StartStillsLoop();
+            return;
+        }
 
         var streamUri = _quality == StreamQuality.Main
             ? Camera.RtspMainUri
@@ -472,9 +500,65 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
         Session?.Resume();
     }
 
+    // --- Stills mode --------------------------------------------------------
+
+    private void StartStillsLoop()
+    {
+        _stillsCts = new CancellationTokenSource();
+        _ = RunStillsAsync(_stillsCts.Token);
+    }
+
+    private async Task RunStillsAsync(CancellationToken ct)
+    {
+        var interval = TimeSpan.FromSeconds(Math.Max(1, _stillsIntervalSeconds));
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var bytes = await _frameSource.GrabAsync(Camera, ct).ConfigureAwait(false);
+                var bmp = bytes is { Length: > 0 } ? DecodeJpeg(bytes) : null;
+                if (bmp is not null)
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        var old = StillFrame;
+                        StillFrame = bmp;
+                        old?.Dispose();
+                    });
+                }
+            }
+            catch (OperationCanceledException) { break; }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Stills grab failed for {Name}", Camera.Name);
+            }
+
+            try { await Task.Delay(interval, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+        }
+    }
+
+    private static Bitmap? DecodeJpeg(byte[] bytes)
+    {
+        try
+        {
+            using var ms = new MemoryStream(bytes);
+            return new Bitmap(ms);
+        }
+        catch
+        {
+            return null; // a truncated / non-image body — keep the previous frame
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         _disposed = true;
+        _stillsCts?.Cancel();
+        _stillsCts?.Dispose();
+        _stillsCts = null;
+        StillFrame?.Dispose();
+        StillFrame = null;
         // No live session for this camera anymore — clear our signal so the
         // registry falls back to the reachability probe alone.
         _statusRegistry.ReportSession(Camera.Id, null);

--- a/src/OpenIPC.Viewer.App/ViewModels/CameraTileViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/CameraTileViewModel.cs
@@ -45,8 +45,10 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
 
     [ObservableProperty] private Bitmap? _stillFrame;
 
-    // Drives the template: Image (stills) vs RtspVideoView (live).
-    public bool StillsMode => _stillsMode;
+    // Drives the template: Image (stills) vs RtspVideoView (live). A camera with
+    // no cheap HTTP still (non-Majestic) stays on live RTSP even when the grid
+    // stills toggle is on, rather than blanking to an empty tile.
+    public bool StillsMode => _stillsMode && _frameSource.Supports(Camera);
 
     // On a stream fault we TCP-probe the camera so the status policy can tell a
     // wedged-but-alive camera (Attention) from a truly unreachable one (Offline).
@@ -301,7 +303,8 @@ public sealed partial class CameraTileViewModel : ViewModelBase, IAsyncDisposabl
         _started = true;
 
         // Stills mode: no decoder, just poll an HTTP snapshot on an interval.
-        if (_stillsMode)
+        // Only for cameras that expose one — others fall through to live RTSP.
+        if (StillsMode)
         {
             StartStillsLoop();
             return;

--- a/src/OpenIPC.Viewer.App/ViewModels/GridPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/GridPageViewModel.cs
@@ -34,6 +34,7 @@ public sealed partial class GridPageViewModel : ViewModelBase,
     private readonly AudioMonitor _audio;
     private readonly IReachabilityProbe _reachability;
     private readonly OpenIPC.Viewer.Core.Status.CameraStatusRegistry _statusRegistry;
+    private readonly OpenIPC.Viewer.Core.Snapshots.ISnapshotFrameSource _frameSource;
     private readonly OpenIPC.Viewer.Core.Persistence.ILayoutRepository _layouts;
     private readonly IDialogService _dialogs;
     private readonly ILoggerFactory _loggerFactory;
@@ -101,6 +102,7 @@ public sealed partial class GridPageViewModel : ViewModelBase,
         AudioMonitor audio,
         IReachabilityProbe reachability,
         OpenIPC.Viewer.Core.Status.CameraStatusRegistry statusRegistry,
+        OpenIPC.Viewer.Core.Snapshots.ISnapshotFrameSource frameSource,
         OpenIPC.Viewer.Core.Persistence.ILayoutRepository layouts,
         IDialogService dialogs,
         ILoggerFactory loggerFactory)
@@ -114,10 +116,14 @@ public sealed partial class GridPageViewModel : ViewModelBase,
         _audio = audio;
         _reachability = reachability;
         _statusRegistry = statusRegistry;
+        _frameSource = frameSource;
         _layouts = layouts;
         _dialogs = dialogs;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<GridPageViewModel>();
+
+        _stillsMode = _userSettings.Current.GridStillsMode;
+        _stillsIntervalSeconds = _userSettings.Current.GridStillsIntervalSeconds;
 
         WeakReferenceMessenger.Default.Register<WindowMinimizedMessage>(this);
         WeakReferenceMessenger.Default.Register<WindowRestoredMessage>(this);
@@ -316,6 +322,52 @@ public sealed partial class GridPageViewModel : ViewModelBase,
             if (Layouts[i].Id == updated.Id) { Layouts[i] = updated; break; }
     }
 
+    // --- Stills mode (grid-wide) --------------------------------------------
+    // Every tile shows a periodic HTTP snapshot instead of a live RTSP session.
+    [ObservableProperty] private bool _stillsMode;
+    [ObservableProperty] private int _stillsIntervalSeconds;
+
+    public int[] StillsIntervalOptions { get; } = { 2, 5, 10, 30, 60 };
+
+    partial void OnStillsModeChanged(bool value) => _ = ApplyStillsChangeAsync();
+
+    partial void OnStillsIntervalSecondsChanged(int value) => _ = ApplyStillsChangeAsync();
+
+    private async Task ApplyStillsChangeAsync()
+    {
+        await PersistStillsAsync().ConfigureAwait(true);
+        await RebuildTilesAsync().ConfigureAwait(true);
+    }
+
+    private async Task PersistStillsAsync()
+    {
+        _suppressSettingsRefresh = true;
+        try
+        {
+            await _userSettings.UpdateAsync(_userSettings.Current with
+            {
+                GridStillsMode = StillsMode,
+                GridStillsIntervalSeconds = StillsIntervalSeconds,
+            }).ConfigureAwait(true);
+        }
+        catch (Exception ex) { _logger.LogWarning(ex, "Persisting stills settings failed"); }
+        finally { _suppressSettingsRefresh = false; }
+    }
+
+    // Full teardown + rebuild so tiles pick up the new stills mode/interval —
+    // RefreshTilesAsync reuses live tiles and wouldn't re-read the flag.
+    private async Task RebuildTilesAsync()
+    {
+        for (var i = Tiles.Count - 1; i >= 0; i--)
+        {
+            var tile = Tiles[i];
+            Tiles.RemoveAt(i);
+            try { await tile.DisposeAsync().ConfigureAwait(true); }
+            catch (Exception ex) { _logger.LogWarning(ex, "Error disposing tile during stills rebuild"); }
+        }
+        await RefreshTilesAsync(CancellationToken.None).ConfigureAwait(true);
+    }
+
     private async Task RefreshTilesAsync(CancellationToken ct)
     {
         // One page = the visual grid (LayoutSize² cells). Within a page two caps
@@ -406,7 +458,7 @@ public sealed partial class GridPageViewModel : ViewModelBase,
                 try { await existing.DisposeAsync().ConfigureAwait(true); }
                 catch (Exception ex) { _logger.LogWarning(ex, "Error releasing stale tile for {Camera}", camera.Name); }
 
-                var rebuilt = new CameraTileViewModel(camera, _coordinator, _directory, _userSettings, _snapshots, _analytics, _analyticsBootstrap, _audio, _reachability, _statusRegistry, _loggerFactory.CreateLogger<CameraTileViewModel>());
+                var rebuilt = new CameraTileViewModel(camera, _coordinator, _directory, _userSettings, _snapshots, _analytics, _analyticsBootstrap, _audio, _reachability, _statusRegistry, _frameSource, StillsMode, StillsIntervalSeconds, _loggerFactory.CreateLogger<CameraTileViewModel>());
                 rebuilt.SetInitialQuality(quality);
                 Tiles.Insert(idx, rebuilt);
                 try { await rebuilt.ActivateAsync(ct).ConfigureAwait(true); }
@@ -414,7 +466,7 @@ public sealed partial class GridPageViewModel : ViewModelBase,
                 continue;
             }
 
-            var tile = new CameraTileViewModel(camera, _coordinator, _directory, _userSettings, _snapshots, _analytics, _analyticsBootstrap, _audio, _reachability, _statusRegistry, _loggerFactory.CreateLogger<CameraTileViewModel>());
+            var tile = new CameraTileViewModel(camera, _coordinator, _directory, _userSettings, _snapshots, _analytics, _analyticsBootstrap, _audio, _reachability, _statusRegistry, _frameSource, StillsMode, StillsIntervalSeconds, _loggerFactory.CreateLogger<CameraTileViewModel>());
             tile.SetInitialQuality(quality);
             Tiles.Add(tile);
             try { await tile.ActivateAsync(ct).ConfigureAwait(true); }

--- a/src/OpenIPC.Viewer.App/Views/Pages/GridPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/GridPage.axaml
@@ -27,6 +27,26 @@
                 ToolTip.Tip="{Binding [Health.Tooltip], Source={x:Static svc:Localizer.Instance}}">
           <Path Classes="lucide" Data="{StaticResource IconActivity}" Stroke="{StaticResource TextPrimaryBrush}" Width="14" Height="14" />
         </Button>
+        <!-- Stills mode: periodic snapshots instead of live video (cheap on big walls). -->
+        <ToggleButton IsChecked="{Binding StillsMode, Mode=TwoWay}"
+                      Padding="10,6" CornerRadius="6" Margin="0,0,8,0"
+                      Foreground="{StaticResource TextPrimaryBrush}"
+                      ToolTip.Tip="{Binding [Grid.Tooltip.Stills], Source={x:Static svc:Localizer.Instance}}">
+          <Path Classes="lucide" Data="{StaticResource IconCamera}"
+                Stroke="{StaticResource TextPrimaryBrush}" Width="15" Height="15" />
+        </ToggleButton>
+        <ComboBox ItemsSource="{Binding StillsIntervalOptions}"
+                  SelectedItem="{Binding StillsIntervalSeconds, Mode=TwoWay}"
+                  IsVisible="{Binding StillsMode}"
+                  MinWidth="64" Margin="0,0,8,0"
+                  x:CompileBindings="False"
+                  VerticalAlignment="Center">
+          <ComboBox.ItemTemplate>
+            <DataTemplate>
+              <TextBlock Text="{Binding StringFormat='{}{0}s'}" />
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
         <Button Content="1×1" Command="{Binding SetLayoutCommand}" CommandParameter="1"
                 Padding="10,6" CornerRadius="6"
                 Background="{StaticResource Bg2Brush}"
@@ -167,7 +187,13 @@
                           Tapped="OnTileTapped"
                           PointerPressed="OnTilePointerPressed"
                           PointerMoved="OnTilePointerMoved">
-                      <controls:RtspVideoView Session="{Binding Session}" />
+                      <controls:RtspVideoView Session="{Binding Session}"
+                                              IsVisible="{Binding !StillsMode}" />
+
+                      <!-- Stills mode: periodic HTTP snapshot instead of live video. -->
+                      <Image Source="{Binding StillFrame}"
+                             Stretch="Uniform"
+                             IsVisible="{Binding StillsMode}" />
 
                       <!-- AI detection boxes (Phase 15.5), above the video. -->
                       <controls:DetectionOverlay Detections="{Binding Detections}"

--- a/src/OpenIPC.Viewer.Composition/SharedComposition.cs
+++ b/src/OpenIPC.Viewer.Composition/SharedComposition.cs
@@ -56,6 +56,9 @@ public static class SharedComposition
         services.AddSingleton<IThumbnailGenerator, OpenIPC.Viewer.Video.Imaging.SkiaThumbnailGenerator>();
         services.AddSingleton<IImageEditor, OpenIPC.Viewer.Video.Imaging.SkiaImageEditor>();
         services.AddSingleton<ISnapshotService, SnapshotService>();
+        // Cheap HTTP still grab (no decoder) — powers the grid "stills" mode and
+        // the timelapse archive.
+        services.AddSingleton<ISnapshotFrameSource, OpenIPC.Viewer.Devices.Snapshots.HttpSnapshotFrameSource>();
 
         // Video
         services.AddSingleton<IVideoEngine, OpenIPC.Viewer.Video.FfmpegVideoEngine>();

--- a/src/OpenIPC.Viewer.Core/Snapshots/ISnapshotFrameSource.cs
+++ b/src/OpenIPC.Viewer.Core/Snapshots/ISnapshotFrameSource.cs
@@ -13,5 +13,12 @@ namespace OpenIPC.Viewer.Core.Snapshots;
 /// </summary>
 public interface ISnapshotFrameSource
 {
+    /// <summary>
+    /// True when the camera exposes a cheap HTTP still endpoint (OpenIPC/Majestic
+    /// <c>/image.jpg</c>). Cameras without one keep their live RTSP view in grid
+    /// stills mode instead of blanking to an empty tile.
+    /// </summary>
+    bool Supports(Camera camera);
+
     Task<byte[]?> GrabAsync(Camera camera, CancellationToken ct);
 }

--- a/src/OpenIPC.Viewer.Core/Snapshots/ISnapshotFrameSource.cs
+++ b/src/OpenIPC.Viewer.Core/Snapshots/ISnapshotFrameSource.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OpenIPC.Viewer.Core.Entities;
+
+namespace OpenIPC.Viewer.Core.Snapshots;
+
+/// <summary>
+/// Grabs a single still frame (JPEG bytes) for a camera as cheaply as possible —
+/// an HTTP snapshot endpoint, never a video decoder. Powers the grid "stills"
+/// mode (periodic image refresh instead of a live RTSP session) and the private
+/// timelapse archive. Returns null when no cheap source is available for the
+/// camera (caller shows a placeholder / keeps the last frame).
+/// </summary>
+public interface ISnapshotFrameSource
+{
+    Task<byte[]?> GrabAsync(Camera camera, CancellationToken ct);
+}

--- a/src/OpenIPC.Viewer.Devices/Snapshots/HttpSnapshotFrameSource.cs
+++ b/src/OpenIPC.Viewer.Devices/Snapshots/HttpSnapshotFrameSource.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OpenIPC.Viewer.Core.Entities;
+using OpenIPC.Viewer.Core.Majestic;
+using OpenIPC.Viewer.Core.Services;
+using OpenIPC.Viewer.Core.Snapshots;
+
+namespace OpenIPC.Viewer.Devices.Snapshots;
+
+/// <summary>
+/// Grabs a still over HTTP without a decoder. Majestic exposes <c>/image.jpg</c>
+/// (full-res, ~50–100 ms) — the primary source for OpenIPC cameras. Non-Majestic
+/// ONVIF cameras will get a GetSnapshotUri path later; until then they return
+/// null and the tile keeps the RTSP live view.
+/// </summary>
+public sealed class HttpSnapshotFrameSource : ISnapshotFrameSource
+{
+    private static readonly TimeSpan GrabTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly IMajesticClient _majestic;
+    private readonly ICameraCredentialsProvider _credentials;
+    private readonly ILogger<HttpSnapshotFrameSource> _logger;
+
+    public HttpSnapshotFrameSource(
+        IMajesticClient majestic,
+        ICameraCredentialsProvider credentials,
+        ILogger<HttpSnapshotFrameSource> logger)
+    {
+        _majestic = majestic;
+        _credentials = credentials;
+        _logger = logger;
+    }
+
+    public async Task<byte[]?> GrabAsync(Camera camera, CancellationToken ct)
+    {
+        if (camera.IsMajestic)
+        {
+            try
+            {
+                var creds = await _credentials.GetCredentialsAsync(camera.Id, ct).ConfigureAwait(false);
+                var endpoint = new MajesticEndpoint(camera.Host, camera.HttpPort, creds);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                cts.CancelAfter(GrabTimeout);
+                var bytes = await _majestic
+                    .SnapshotJpegAsync(endpoint, new MajesticSnapshotOptions(), cts.Token)
+                    .ConfigureAwait(false);
+                if (bytes is { Length: > 0 })
+                    return bytes;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Majestic snapshot grab failed for {Camera}", camera.Name);
+            }
+        }
+
+        // TODO: ONVIF GetSnapshotUri → HTTP GET for non-Majestic cameras.
+        return null;
+    }
+}

--- a/src/OpenIPC.Viewer.Devices/Snapshots/HttpSnapshotFrameSource.cs
+++ b/src/OpenIPC.Viewer.Devices/Snapshots/HttpSnapshotFrameSource.cs
@@ -33,6 +33,10 @@ public sealed class HttpSnapshotFrameSource : ISnapshotFrameSource
         _logger = logger;
     }
 
+    // Only OpenIPC/Majestic exposes /image.jpg today. ONVIF GetSnapshotUri will
+    // extend this to generic ONVIF cameras later.
+    public bool Supports(Camera camera) => camera.IsMajestic;
+
     public async Task<byte[]?> GrabAsync(Camera camera, CancellationToken ct)
     {
         if (camera.IsMajestic)


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- ISnapshotFrameSource + Majestic HTTP JPEG grabber (no decoder)
- CameraTileViewModel stills mode: periodic snapshot Image instead of live RTSP
- grid toolbar toggle + interval combo; persisted; full tile rebuild on change
## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [x] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
