### PR TITLE
fix(android): disable AOT (malformed libaot-*.so broke APK install)

### DIFF
--- a/src/OpenIPC.Viewer.Android/OpenIPC.Viewer.Android.csproj
+++ b/src/OpenIPC.Viewer.Android/OpenIPC.Viewer.Android.csproj
@@ -9,8 +9,8 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ApplicationId>org.openipc.viewer</ApplicationId>
-    <ApplicationVersion>30000</ApplicationVersion>
-    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
+    <ApplicationVersion>30001</ApplicationVersion>
+    <ApplicationDisplayVersion>0.3.1</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
     <!-- Full AOT (Release default) emits libaot-*.so; on the current workload

--- a/src/OpenIPC.Viewer.Android/OpenIPC.Viewer.Android.csproj
+++ b/src/OpenIPC.Viewer.Android/OpenIPC.Viewer.Android.csproj
@@ -9,10 +9,17 @@
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ApplicationId>org.openipc.viewer</ApplicationId>
-    <ApplicationVersion>1</ApplicationVersion>
-    <ApplicationDisplayVersion>0.1.0-beta</ApplicationDisplayVersion>
+    <ApplicationVersion>30000</ApplicationVersion>
+    <ApplicationDisplayVersion>0.3.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <!-- Full AOT (Release default) emits libaot-*.so; on the current workload
+         (android 36.1.43 / build-tools 35) their packaging is malformed — a ZIP
+         entry's declared size is off by a few bytes, so apksigner/Android reject
+         the APK as corrupt ("INSTALL_PARSE_FAILED_NO_CERTIFICATES", digest
+         mismatch). We don't need AOT yet, so keep it off until we revisit it as a
+         page-alignment-safe polish step. -->
+    <RunAOTCompilation>false</RunAOTCompilation>
     <RuntimeIdentifiers>android-arm64;android-x64</RuntimeIdentifiers>
     <!--
       FFmpeg native libs are produced by tools/build-ffmpeg-android.sh from


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- Release full-AOT (default) packaged libaot-*.so with a wrong ZIP entry size on
  the current workload → signed APKs failed to install as 'corrupt package'
  (INSTALL_PARSE_FAILED_NO_CERTIFICATES / v3 digest mismatch). RunAOTCompilation=false
  → valid 66MB APK, verified install + launch on API 36 emulator.
- bump version to 0.3.0 (versionCode 30000); was stuck at 1 / 0.1.0-beta

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [x] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
