### PR TITLE
fix(android): allow cleartext HTTP (Majestic panel + snapshots dead on-device)

### DIFF
--- a/src/OpenIPC.Viewer.Android/Properties/AndroidManifest.xml
+++ b/src/OpenIPC.Viewer.Android/Properties/AndroidManifest.xml
@@ -22,7 +22,14 @@
                android:roundIcon="@mipmap/icon"
                android:allowBackup="true"
                android:supportsRtl="true"
-               android:name=".MainApplication">
+               android:name=".MainApplication"
+               android:usesCleartextTraffic="true">
+    <!-- usesCleartextTraffic: OpenIPC cameras speak plain HTTP on the LAN
+         (Majestic config.json + image.jpg snapshots, no TLS). Android blocks
+         cleartext HTTP by default for targetSdk>=28, which silently killed every
+         camera HTTP call on-device — the Majestic panel never loaded and
+         snapshots failed, while RTSP video (not HTTP) still worked. LAN devices
+         have no certs, so cleartext is required. -->
     <!-- Phase 14.6 — share sheet. FileProvider grants the receiving app a
          scoped, temporary read URI to a snapshot instead of a file:// path. -->
     <provider android:name="androidx.core.content.FileProvider"

--- a/src/OpenIPC.Viewer.App/Views/Pages/SingleCameraPage.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SingleCameraPage.axaml.cs
@@ -56,16 +56,24 @@ public sealed partial class SingleCameraPage : UserControl
     // panel, and a Grid alone would just run the panel off the bottom. Switch the
     // video row to a fixed 16:9 preview and let PageScroll scroll; on wider
     // viewports keep the fill layout (star row, scrolling disabled).
-    private void OnPageSizeChanged(object? sender, SizeChangedEventArgs e)
+    private void OnPageSizeChanged(object? sender, SizeChangedEventArgs e) =>
+        ApplyResponsiveLayout(e.NewSize.Width);
+
+    private void ApplyResponsiveLayout(double width)
     {
-        var width = e.NewSize.Width;
+        // Width can be 0 before the first arrange (e.g. when called from Loaded).
+        // A mobile head is always a phone-width viewport, so fall back to the
+        // mobile layout there — this guarantees the page scrolls and the Majestic
+        // panel below the video is reachable even if SizeChanged hasn't fired yet.
         if (width <= 0)
-            return;
+            width = OpenIPC.Viewer.App.Services.OverlayDialogPresenter.IsMobile ? 400 : 1000;
 
         var videoRow = RootGrid.RowDefinitions[1];
         if (width < MobileBreakpoint)
         {
-            videoRow.Height = new GridLength(System.Math.Round(width * 9.0 / 16.0));
+            var videoHeight = System.Math.Round(width * 9.0 / 16.0);
+            if (videoHeight < 160) videoHeight = 200; // sane floor before real measure
+            videoRow.Height = new GridLength(videoHeight);
             PageScroll.VerticalScrollBarVisibility = Avalonia.Controls.Primitives.ScrollBarVisibility.Auto;
         }
         else
@@ -89,6 +97,11 @@ public sealed partial class SingleCameraPage : UserControl
 
     private async void OnLoaded(object? sender, RoutedEventArgs e)
     {
+        // Engage the responsive layout up front — SizeChanged only fires on a
+        // change, which on some Android layouts may not happen before the page
+        // is shown, leaving it in the desktop (fill, no-scroll) state.
+        ApplyResponsiveLayout(Bounds.Width);
+
         if (Vm is { } vm)
             await vm.ActivateAsync(CancellationToken.None);
     }


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- targetSdk 36 blocks cleartext http:// by default, silently killing every camera
  HTTP call on Android (Majestic config.json never loaded, image.jpg snapshots
  failed) while RTSP video still worked. Cameras are LAN devices with no TLS →
  usesCleartextTraffic=true.

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
