### PR TITLE
feat(mobile): SSH soft keyboard, risky-tools gate, animated splash on mobile

### DIFF
--- a/src/OpenIPC.Viewer.App/App.axaml.cs
+++ b/src/OpenIPC.Viewer.App/App.axaml.cs
@@ -1,8 +1,11 @@
 using System;
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using OpenIPC.Viewer.App.Services;
 using OpenIPC.Viewer.App.ViewModels;
 using OpenIPC.Viewer.App.Views;
 
@@ -16,41 +19,99 @@ public sealed class App : Application
     // AvaloniaMainActivity<App> requires on Android.
     public static IServiceProvider? Services { get; set; }
 
+    // How long the mobile splash overlay stays before fading. The Android boot
+    // is fast, so without a minimum beat the splash would just flicker.
+    private static readonly TimeSpan MobileSplashMinDuration = TimeSpan.FromSeconds(1.6);
+    private static readonly TimeSpan MobileSplashFadeDuration = TimeSpan.FromMilliseconds(400);
+
     public override void Initialize() => AvaloniaXamlLoader.Load(this);
 
     public override void OnFrameworkInitializationCompleted()
     {
         if (Services is not null)
         {
+            // Settings → Appearance: the animated splash is our own feature (not
+            // the OS launch screen), so the user can turn it off entirely.
+            var showSplash = Services.GetService<UserSettingsService>()?.Current.ShowSplash ?? true;
+
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-            {
-                // Desktop shows a splash that runs migrations + event ingestion
-                // with visible progress, then swaps in the main window. (Android
-                // runs that bootstrap in MainApplication and uses the single-view
-                // branch below.)
-                var startup = Services.GetRequiredService<StartupViewModel>();
-                var splash = new StartupWindow { DataContext = startup };
-
-                startup.Completed += () =>
-                {
-                    var vm = Services.GetRequiredService<MainWindowViewModel>();
-                    var main = new MainWindow { DataContext = vm };
-                    desktop.MainWindow = main;
-                    main.Show();
-                    splash.Close();
-                };
-
-                desktop.MainWindow = splash;
-                // Start init only once the splash is actually on screen.
-                splash.Opened += (_, _) => _ = startup.RunAsync();
-            }
+                StartDesktop(desktop, showSplash);
             else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
-            {
-                var vm = Services.GetRequiredService<MainWindowViewModel>();
-                singleView.MainView = new MainView { DataContext = vm };
-            }
+                StartSingleView(singleView, showSplash);
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    // Desktop shows a splash that runs migrations + event ingestion with visible
+    // progress, then swaps in the main window. With the splash disabled the same
+    // init runs window-less and the shell opens straight away when it finishes —
+    // but a failure still needs the retry/exit UI, so the StartupWindow is
+    // created lazily in that case instead of being lost.
+    private static void StartDesktop(IClassicDesktopStyleApplicationLifetime desktop, bool showSplash)
+    {
+        var startup = Services!.GetRequiredService<StartupViewModel>();
+
+        if (showSplash)
+        {
+            var splash = new StartupWindow { DataContext = startup };
+            startup.Completed += () => ShowMainWindow(desktop, splash);
+            desktop.MainWindow = splash;
+            // Start init only once the splash is actually on screen.
+            splash.Opened += (_, _) => _ = startup.RunAsync();
+            return;
+        }
+
+        StartupWindow? errorWindow = null;
+        startup.Completed += () => ShowMainWindow(desktop, errorWindow);
+        startup.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(StartupViewModel.HasError) ||
+                !startup.HasError || errorWindow is not null)
+                return;
+            errorWindow = new StartupWindow { DataContext = startup };
+            desktop.MainWindow = errorWindow;
+            errorWindow.Show();
+        };
+        _ = startup.RunAsync();
+    }
+
+    private static void ShowMainWindow(IClassicDesktopStyleApplicationLifetime desktop, Window? toClose)
+    {
+        var vm = Services!.GetRequiredService<MainWindowViewModel>();
+        var main = new MainWindow { DataContext = vm };
+        desktop.MainWindow = main;
+        main.Show();
+        toClose?.Close();
+    }
+
+    // Android/iOS: migrations already ran in the platform host, so the splash is
+    // a purely visual overlay — MainView initializes underneath, and after a
+    // minimum beat the overlay fades out and leaves the tree.
+    private static void StartSingleView(ISingleViewApplicationLifetime singleView, bool showSplash)
+    {
+        var vm = Services!.GetRequiredService<MainWindowViewModel>();
+        var main = new MainView { DataContext = vm };
+
+        if (!showSplash)
+        {
+            singleView.MainView = main;
+            return;
+        }
+
+        var splash = new MobileSplashView();
+        var host = new Panel();
+        host.Children.Add(main);
+        host.Children.Add(splash);
+        singleView.MainView = host;
+
+        // Count the minimum beat from the splash's first layout pass, not from
+        // here — Avalonia's first Android frame lands well after lifetime setup,
+        // and a timer started now can remove the splash before it's ever drawn.
+        splash.Loaded += (_, _) => DispatcherTimer.RunOnce(() =>
+        {
+            splash.Opacity = 0; // MobileSplashView carries the Opacity transition
+            DispatcherTimer.RunOnce(() => host.Children.Remove(splash), MobileSplashFadeDuration);
+        }, MobileSplashMinDuration);
     }
 }

--- a/src/OpenIPC.Viewer.App/Controls/SplashAperture.axaml
+++ b/src/OpenIPC.Viewer.App/Controls/SplashAperture.axaml
@@ -1,0 +1,83 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="OpenIPC.Viewer.App.Controls.SplashAperture">
+
+  <!-- Animated OpenIPC aperture mark (the splash "camera eye"). Extracted from
+       StartupWindow so the desktop splash and the mobile startup overlay share
+       one implementation. Scales to whatever Width/Height the consumer sets. -->
+
+  <UserControl.Styles>
+    <!-- Occasional "aperture blink": squash the whole mark vertically for a few
+         frames on a long loop, reading as a blink rather than a flicker. -->
+    <Style Selector="Canvas.mark">
+      <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
+    </Style>
+    <Style Selector="Canvas.mark">
+      <Style.Animations>
+        <Animation Duration="0:0:3.8" IterationCount="INFINITE">
+          <KeyFrame Cue="0%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
+          <KeyFrame Cue="88%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
+          <KeyFrame Cue="93%"><Setter Property="ScaleTransform.ScaleY" Value="0.08" /></KeyFrame>
+          <KeyFrame Cue="98%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
+          <KeyFrame Cue="100%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
+        </Animation>
+      </Style.Animations>
+    </Style>
+
+    <!-- The "pupil" looks left↔right, like a camera scanning the room. -->
+    <Style Selector="Ellipse.dot">
+      <Style.Animations>
+        <Animation Duration="0:0:4" IterationCount="INFINITE" Easing="SineEaseInOut">
+          <KeyFrame Cue="0%"><Setter Property="TranslateTransform.X" Value="0" /></KeyFrame>
+          <KeyFrame Cue="22%"><Setter Property="TranslateTransform.X" Value="-9" /></KeyFrame>
+          <KeyFrame Cue="50%"><Setter Property="TranslateTransform.X" Value="0" /></KeyFrame>
+          <KeyFrame Cue="72%"><Setter Property="TranslateTransform.X" Value="9" /></KeyFrame>
+          <KeyFrame Cue="100%"><Setter Property="TranslateTransform.X" Value="0" /></KeyFrame>
+        </Animation>
+      </Style.Animations>
+    </Style>
+
+    <!-- Accent glow ring brightens as the dot contracts (the "focus" snap). -->
+    <Style Selector="Ellipse.glow">
+      <Style.Animations>
+        <Animation Duration="0:0:1.8" IterationCount="INFINITE" Easing="SineEaseInOut">
+          <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.15" /></KeyFrame>
+          <KeyFrame Cue="50%"><Setter Property="Opacity" Value="0.55" /></KeyFrame>
+          <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0.15" /></KeyFrame>
+        </Animation>
+      </Style.Animations>
+    </Style>
+  </UserControl.Styles>
+
+  <Viewbox Stretch="Uniform">
+    <Canvas Width="100" Height="100">
+      <Canvas Classes="mark" Width="100" Height="100">
+        <!-- Left chevron < -->
+        <Path Data="M33,29 L5,50 L33,71"
+              Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
+              StrokeLineCap="Flat" StrokeJoin="Round" />
+        <!-- Right chevron > -->
+        <Path Data="M67,29 L95,50 L67,71"
+              Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
+              StrokeLineCap="Flat" StrokeJoin="Round" />
+        <!-- Top cap arc ⌒ -->
+        <Path Data="M37,27 C43,12 57,12 63,27"
+              Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
+              StrokeLineCap="Round" />
+        <!-- Bottom cap arc ⌣ -->
+        <Path Data="M37,73 C43,88 57,88 63,73"
+              Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
+              StrokeLineCap="Round" />
+        <!-- Accent focus glow behind the dot -->
+        <Ellipse Classes="glow" Canvas.Left="32" Canvas.Top="32"
+                 Width="36" Height="36"
+                 Stroke="{StaticResource AccentBrush}" StrokeThickness="6" />
+        <!-- Center dot (focus pulse) -->
+        <Ellipse Classes="dot" Canvas.Left="37" Canvas.Top="37"
+                 Width="26" Height="26"
+                 Fill="{StaticResource TextPrimaryBrush}" />
+      </Canvas>
+    </Canvas>
+  </Viewbox>
+
+</UserControl>

--- a/src/OpenIPC.Viewer.App/Controls/SplashAperture.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Controls/SplashAperture.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace OpenIPC.Viewer.App.Controls;
+
+public sealed partial class SplashAperture : UserControl
+{
+    public SplashAperture() => InitializeComponent();
+}

--- a/src/OpenIPC.Viewer.App/Services/Localizer.cs
+++ b/src/OpenIPC.Viewer.App/Services/Localizer.cs
@@ -211,6 +211,7 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Settings.Title"] = "Settings",
         ["Settings.Appearance"] = "Appearance",
         ["Settings.Appearance.Language"] = "Language",
+        ["Settings.Appearance.ShowSplash"] = "Show animated splash screen on launch",
         ["Settings.Video"] = "Video",
         ["Settings.Recording"] = "Recording",
         ["Settings.Discovery"] = "Discovery",
@@ -247,7 +248,7 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Settings.Discovery.AutoScan"] = "Run WS-Discovery on launch",
 
         ["Settings.Advanced.VerboseLogging"] = "Verbose logging (debug level)",
-        ["Settings.Advanced.RawConfigEditor"] = "Allow raw Majestic config editing (advanced)",
+        ["Settings.Advanced.RawConfigEditor"] = "Allow risky device tools (raw config editing, file manager)",
         ["Settings.Advanced.OpenAppData"] = "Open app data folder",
 
         ["Settings.About.Repository"] = "GitHub repository →",
@@ -353,9 +354,6 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Ssh.HostKeyChanged.Message"] = "The SSH key presented by {0} does not match the one pinned earlier.\n\nNew:    {1}\nPinned: {2}\n\nThis is expected if the camera was reflashed or replaced — but could also mean someone is intercepting the connection. Trust the new key and continue?",
         ["Ssh.HostKeyChanged.Trust"] = "Trust new key",
         ["FileManager.Title"] = "Files",
-        ["FileManager.RiskTitle"] = "Browse camera files?",
-        ["FileManager.RiskMessage"] = "This opens the camera's live filesystem over SSH. Deleting, moving or overwriting the wrong file can break the camera and require a reflash. Only continue if you know what you're doing.",
-        ["FileManager.RiskConfirm"] = "Open anyway",
         ["FileManager.Connecting"] = "Connecting…",
         ["FileManager.NoCreds"] = "No SSH credentials set for this camera.",
         ["FileManager.FailedFormat"] = "Error: {0}",
@@ -676,6 +674,7 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Settings.Title"] = "Настройки",
         ["Settings.Appearance"] = "Внешний вид",
         ["Settings.Appearance.Language"] = "Язык",
+        ["Settings.Appearance.ShowSplash"] = "Показывать анимированную заставку при запуске",
         ["Settings.Video"] = "Видео",
         ["Settings.Recording"] = "Запись",
         ["Settings.Discovery"] = "Поиск",
@@ -712,7 +711,7 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Settings.Discovery.AutoScan"] = "Запускать WS-Discovery при старте",
 
         ["Settings.Advanced.VerboseLogging"] = "Подробные логи (debug)",
-        ["Settings.Advanced.RawConfigEditor"] = "Разрешить правку raw-конфига Majestic (продвинутое)",
+        ["Settings.Advanced.RawConfigEditor"] = "Разрешить рискованные инструменты (raw-конфиг, файловый менеджер)",
         ["Settings.Advanced.OpenAppData"] = "Открыть папку данных",
 
         ["Settings.About.Repository"] = "Репозиторий на GitHub →",
@@ -818,9 +817,6 @@ public sealed class Localizer : INotifyPropertyChanged
         ["Ssh.HostKeyChanged.Message"] = "SSH-ключ, который предъявил {0}, не совпадает с ранее сохранённым.\n\nНовый:      {1}\nСохранённый: {2}\n\nЭто нормально, если камеру перепрошили или заменили, — но может означать и перехват соединения. Доверять новому ключу и продолжить?",
         ["Ssh.HostKeyChanged.Trust"] = "Доверять ключу",
         ["FileManager.Title"] = "Файлы",
-        ["FileManager.RiskTitle"] = "Открыть файлы камеры?",
-        ["FileManager.RiskMessage"] = "Откроется живая файловая система камеры по SSH. Удаление, перемещение или перезапись не того файла может сломать камеру вплоть до перепрошивки. Продолжайте, только если понимаете, что делаете.",
-        ["FileManager.RiskConfirm"] = "Всё равно открыть",
         ["FileManager.Connecting"] = "Подключение…",
         ["FileManager.NoCreds"] = "Для камеры не заданы SSH-учётные данные.",
         ["FileManager.FailedFormat"] = "Ошибка: {0}",

--- a/src/OpenIPC.Viewer.App/Services/UserSettings.cs
+++ b/src/OpenIPC.Viewer.App/Services/UserSettings.cs
@@ -28,8 +28,14 @@ public sealed record UserSettings(
     // "system" follows CurrentUICulture; "en"/"ru" force a specific locale.
     string Language = "system",
     bool WelcomeShown = false,
-    // Unlocks the "Edit raw" button in the Phase 5 Majestic panel. Off by
-    // default — a typo here can leave the camera in a non-bootable state.
+    // The animated startup splash (our in-app one, not the OS launch screen).
+    // Applies to both the desktop StartupWindow and the mobile overlay.
+    bool ShowSplash = true,
+    // Shared "risky device tools" gate: unlocks the raw Majestic config editors
+    // (HTTP + SSH) on the camera page AND the SSH file manager in the library.
+    // Off by default — a typo in the config or a deleted system file can leave
+    // the camera in a non-bootable state. The toggle itself is the consent, so
+    // the gated tools open without an extra per-use warning.
     bool RawConfigEditorEnabled = false,
     // SSH device suite (Phase 13). StrictHostKey on → a changed host key is
     // refused (TOFU); off → the new key is accepted and re-pinned (e.g. after

--- a/src/OpenIPC.Viewer.App/ViewModels/CameraLibraryPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/CameraLibraryPageViewModel.cs
@@ -89,6 +89,10 @@ public sealed partial class CameraLibraryPageViewModel : ViewModelBase, IRecipie
         _statusRegistry = statusRegistry;
         _logger = logger;
         WeakReferenceMessenger.Default.Register<ConfigImportedMessage>(this);
+        // Toggling "risky device tools" in Settings shows/hides the Files button
+        // without reopening the page. The update can arrive off the UI thread.
+        _userSettings.Changed += (_, _) => Avalonia.Threading.Dispatcher.UIThread.Post(
+            () => OnPropertyChanged(nameof(IsFileManagerEnabled)));
         // Live status: a grid session's verdict (incl. Attention) flows here so a
         // library row reflects it, not just its own probe.
         _statusRegistry.Changed += OnStatusRegistryChanged;
@@ -445,20 +449,16 @@ public sealed partial class CameraLibraryPageViewModel : ViewModelBase, IRecipie
         await _dialogs.OpenSshTerminalAsync(vm).ConfigureAwait(true);
     }
 
+    // The file manager browses/edits the camera's live root filesystem over
+    // SSH — deleting or overwriting the wrong file can brick the device. The
+    // button only shows once the shared "risky device tools" toggle (Settings →
+    // Advanced) is on; that opt-in is the consent, so no per-open warning here.
+    public bool IsFileManagerEnabled => _userSettings.Current.RawConfigEditorEnabled;
+
     [RelayCommand]
     private async Task OpenFileManagerAsync(CameraRowViewModel? row)
     {
         if (row is null)
-            return;
-        // The file manager browses/edits the camera's live root filesystem over
-        // SSH — deleting or overwriting the wrong file can brick the device. Gate
-        // it behind an explicit warning the user must accept.
-        var ok = await _dialogs.ConfirmAsync(
-            Localizer.Instance["FileManager.RiskTitle"],
-            Localizer.Instance["FileManager.RiskMessage"],
-            Localizer.Instance["FileManager.RiskConfirm"],
-            Localizer.Instance["Common.Cancel"]).ConfigureAwait(true);
-        if (!ok)
             return;
         var vm = _fileManagerFactory.Create(row.Camera);
         await _dialogs.OpenFileManagerAsync(vm).ConfigureAwait(true);

--- a/src/OpenIPC.Viewer.App/ViewModels/SettingsPageViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/SettingsPageViewModel.cs
@@ -44,6 +44,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
 
     [ObservableProperty] private NetworkInterfaceOption? _selectedNetworkInterface;
     [ObservableProperty] private string _language = "system";
+    [ObservableProperty] private bool _showSplash = true;
 
     // SSH section (Phase 13).
     [ObservableProperty] private bool _sshStrictHostKey = true;
@@ -204,6 +205,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
                 ?? NetworkInterfaceOptions[0];
             RecordingsDirOverride = s.RecordingsDirOverride;
             Language = s.Language;
+            ShowSplash = s.ShowSplash;
             SshStrictHostKey = s.SshStrictHostKey;
             SshDefaultPort = s.SshDefaultPort;
             SshTerminalFontSize = s.SshTerminalFontSize;
@@ -234,6 +236,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
     partial void OnSelectedNetworkInterfaceChanged(NetworkInterfaceOption? value) => Persist();
     partial void OnRecordingsDirOverrideChanged(string value) => Persist();
     partial void OnLanguageChanged(string value) => Persist();
+    partial void OnShowSplashChanged(bool value) => Persist();
     partial void OnSshStrictHostKeyChanged(bool value) => Persist();
     partial void OnSshDefaultPortChanged(int value) => Persist();
     partial void OnSshTerminalFontSizeChanged(int value) => Persist();
@@ -263,6 +266,7 @@ public sealed partial class SettingsPageViewModel : ViewModelBase
             PreferredNetworkInterface = SelectedNetworkInterface?.Value ?? "",
             RecordingsDirOverride = RecordingsDirOverride,
             Language = Language,
+            ShowSplash = ShowSplash,
             SshStrictHostKey = SshStrictHostKey,
             SshDefaultPort = SshDefaultPort,
             SshTerminalFontSize = SshTerminalFontSize,

--- a/src/OpenIPC.Viewer.App/Views/Dialogs/SshTerminalContent.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/SshTerminalContent.axaml
@@ -8,7 +8,27 @@
              MinWidth="280" MinHeight="320"
              Background="#0c0f14">
 
-  <Grid RowDefinitions="Auto,Auto,*">
+  <UserControl.Styles>
+    <!-- Special-keys bar (mobile only) — terminal-styled, non-focusable so a
+         tap doesn't steal focus from the IME proxy (the keyboard would hide). -->
+    <Style Selector="Button.termkey, ToggleButton.termkey">
+      <Setter Property="Focusable" Value="False" />
+      <Setter Property="Padding" Value="12,4" />
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontFamily" Value="{StaticResource FontMono}" />
+      <Setter Property="Background" Value="#1a1f28" />
+      <Setter Property="Foreground" Value="#cccccc" />
+      <Setter Property="BorderBrush" Value="#2a3140" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="ToggleButton.termkey:checked /template/ ContentPresenter">
+      <Setter Property="Background" Value="#2472c8" />
+      <Setter Property="Foreground" Value="#ffffff" />
+    </Style>
+  </UserControl.Styles>
+
+  <Grid RowDefinitions="Auto,Auto,Auto,*">
 
     <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Margin="12,8">
       <TextBlock Grid.Column="0"
@@ -35,7 +55,47 @@
                  TextWrapping="Wrap" />
     </Border>
 
-    <controls:TerminalView Grid.Row="2" Name="Term" />
+    <!-- Special keys soft keyboards don't have. Shown by code-behind on
+         Android/iOS only; scrolls sideways on very narrow phones. -->
+    <Border Grid.Row="2" Name="KeyBar"
+            IsVisible="False"
+            Background="#12161d"
+            BorderBrush="#2a3140" BorderThickness="0,1"
+            Padding="8,6">
+      <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+        <StackPanel Orientation="Horizontal" Spacing="6">
+          <Button Classes="termkey" Name="KeyEsc" Content="Esc" />
+          <Button Classes="termkey" Name="KeyTab" Content="Tab" />
+          <ToggleButton Classes="termkey" Name="KeyCtrl" Content="Ctrl" />
+          <Button Classes="termkey" Name="KeyArrowUp" Content="↑" />
+          <Button Classes="termkey" Name="KeyArrowDown" Content="↓" />
+          <Button Classes="termkey" Name="KeyArrowLeft" Content="←" />
+          <Button Classes="termkey" Name="KeyArrowRight" Content="→" />
+        </StackPanel>
+      </ScrollViewer>
+    </Border>
+
+    <Panel Grid.Row="3">
+      <controls:TerminalView Name="Term" />
+      <!-- Invisible IME proxy (mobile only). TerminalView is a custom-drawn
+           Control that never advertises text input, so Android's soft keyboard
+           won't open for it. On mobile this TextBox holds focus instead: it
+           triggers the IME, and code-behind forwards everything it receives
+           into the shell, keeping a one-space sentinel in the box so backspace
+           produces a detectable change. Kept invisible+disabled on desktop,
+           where the hardware keyboard path through TerminalView works. -->
+      <TextBox Name="ImeProxy"
+               Width="4" Height="4" MinWidth="4" MinHeight="4"
+               Padding="0" BorderThickness="0"
+               Opacity="0"
+               HorizontalAlignment="Left" VerticalAlignment="Bottom"
+               IsVisible="False"
+               IsTabStop="False"
+               IsHitTestVisible="False"
+               TextInputOptions.ShowSuggestions="False"
+               TextInputOptions.IsSensitive="True"
+               TextInputOptions.AutoCapitalization="False" />
+    </Panel>
   </Grid>
 
 </UserControl>

--- a/src/OpenIPC.Viewer.App/Views/Dialogs/SshTerminalContent.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/SshTerminalContent.axaml.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using OpenIPC.Viewer.App.Controls;
 using OpenIPC.Viewer.App.ViewModels;
 
@@ -9,8 +12,20 @@ namespace OpenIPC.Viewer.App.Views.Dialogs;
 
 public sealed partial class SshTerminalContent : UserControl
 {
+    // Mobile soft keyboards can't focus the custom-drawn TerminalView, so an
+    // invisible TextBox (ImeProxy) holds focus there and everything it receives
+    // is forwarded into the shell. The box always contains this sentinel: typed
+    // characters land after it, and an IME "delete" that eats the sentinel is
+    // how we detect backspace (many IMEs send deleteSurroundingText instead of
+    // a DEL key event, which never reaches KeyDown).
+    private const string Sentinel = " ";
+    private static readonly bool UseImeProxy = OperatingSystem.IsAndroid() || OperatingSystem.IsIOS();
+
     private readonly TaskCompletionSource<bool> _tcs = new();
     private TerminalView? _term;
+    private TextBox? _proxy;
+    private ToggleButton? _ctrlKey;
+    private bool _suppressProxyChange;
     private bool _started;
     private bool _connected;
 
@@ -22,9 +37,42 @@ public sealed partial class SshTerminalContent : UserControl
         _term = this.FindControl<TerminalView>("Term");
         var close = this.FindControl<Button>("CloseButton")!;
         close.Click += OnClose;
+
+        if (UseImeProxy)
+            SetUpImeProxy();
     }
 
-    private void OnClose(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    private void SetUpImeProxy()
+    {
+        this.FindControl<Border>("KeyBar")!.IsVisible = true;
+
+        _proxy = this.FindControl<TextBox>("ImeProxy")!;
+        _proxy.IsVisible = true;
+        // Tunnel so Enter/arrows/backspace are ours before the TextBox edits
+        // its own text (which would corrupt the sentinel bookkeeping).
+        _proxy.AddHandler(KeyDownEvent, OnProxyKeyDown, RoutingStrategies.Tunnel);
+        _proxy.TextChanged += OnProxyTextChanged;
+        ResetProxy();
+
+        _ctrlKey = this.FindControl<ToggleButton>("KeyCtrl");
+        WireKey("KeyEsc", "\x1b");
+        WireKey("KeyTab", "\t");
+        WireKey("KeyArrowUp", "\x1b[A");
+        WireKey("KeyArrowDown", "\x1b[B");
+        WireKey("KeyArrowRight", "\x1b[C");
+        WireKey("KeyArrowLeft", "\x1b[D");
+    }
+
+    private void WireKey(string buttonName, string sequence)
+    {
+        this.FindControl<Button>(buttonName)!.Click += (_, _) =>
+        {
+            SendInput(sequence);
+            FocusInput();
+        };
+    }
+
+    private void OnClose(object? sender, RoutedEventArgs e)
     {
         // Desktop hosts in a Window; mobile in an overlay awaiting Completion.
         if (VisualRoot is Window w)
@@ -42,14 +90,111 @@ public sealed partial class SshTerminalContent : UserControl
 
         _term.Emulator = vm.Emulator;
         _term.TerminalFontSize = vm.FontSize;
-        _term.Input += (_, text) => _ = vm.SendAsync(text);
+        _term.Input += (_, text) => SendInput(text);
         // Defer the connect until the terminal has been measured: SSH.NET's
         // ShellStream can't be resized mid-session, so the PTY keeps whatever
         // size we open it with. Opening at the default 80x24 before layout means
         // a narrow (phone) view gets 80-column output that overflows off-screen.
         // Wait for the first real grid size, then open the shell to match.
         _term.GridResized += OnGridResized;
-        _term.Focus();
+
+        if (UseImeProxy)
+        {
+            // Focus lives on the proxy; a tap on the terminal (e.g. after the
+            // user dismissed the keyboard) re-focuses it so the IME reopens.
+            _term.Focusable = false;
+            _term.PointerPressed += (_, _) => FocusInput();
+        }
+        // Focusing during attach is too early for Android's IME — the input
+        // connection isn't wired yet, so the keyboard wouldn't open until the
+        // user tapped the terminal. Post the initial focus past layout instead.
+        Avalonia.Threading.Dispatcher.UIThread.Post(FocusInput, Avalonia.Threading.DispatcherPriority.Loaded);
+    }
+
+    private void FocusInput()
+    {
+        if (UseImeProxy)
+            _proxy?.Focus();
+        else
+            _term?.Focus();
+    }
+
+    // Everything user-typed funnels through here so the on-screen Ctrl key can
+    // modify the next character regardless of which path produced it.
+    private void SendInput(string text)
+    {
+        if (DataContext is not SshTerminalViewModel vm || text.Length == 0)
+            return;
+
+        // Soft keyboards commit Enter as '\n'; shells expect CR.
+        text = text.Replace('\n', '\r');
+
+        if (_ctrlKey?.IsChecked == true && text.Length == 1 && char.IsAsciiLetter(text[0]))
+        {
+            text = ((char)(char.ToUpperInvariant(text[0]) - 'A' + 1)).ToString();
+            _ctrlKey.IsChecked = false;
+        }
+        _ = vm.SendAsync(text);
+    }
+
+    private void OnProxyKeyDown(object? sender, KeyEventArgs e)
+    {
+        // Hardware Ctrl+letter (external keyboard on a tablet).
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.Key is >= Key.A and <= Key.Z)
+        {
+            SendInput(((char)(e.Key - Key.A + 1)).ToString());
+            e.Handled = true;
+            return;
+        }
+
+        var seq = e.Key switch
+        {
+            Key.Enter => "\r",
+            Key.Back => "\x7f",
+            Key.Tab => "\t",
+            Key.Escape => "\x1b",
+            Key.Up => "\x1b[A",
+            Key.Down => "\x1b[B",
+            Key.Right => "\x1b[C",
+            Key.Left => "\x1b[D",
+            Key.Home => "\x1b[H",
+            Key.End => "\x1b[F",
+            _ => null,
+        };
+        if (seq is not null)
+        {
+            SendInput(seq);
+            e.Handled = true;
+        }
+    }
+
+    private void OnProxyTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (_suppressProxyChange || _proxy is null)
+            return;
+
+        var text = _proxy.Text ?? "";
+        if (text == Sentinel)
+            return;
+
+        if (text.StartsWith(Sentinel, StringComparison.Ordinal))
+            SendInput(text[Sentinel.Length..]);          // typed characters
+        else if (text.Length < Sentinel.Length)
+            SendInput("\x7f");                           // IME ate the sentinel → backspace
+        else
+            SendInput(text);                             // IME replaced everything (autocorrect) — best effort
+
+        ResetProxy();
+    }
+
+    private void ResetProxy()
+    {
+        if (_proxy is null)
+            return;
+        _suppressProxyChange = true;
+        _proxy.Text = Sentinel;
+        _proxy.CaretIndex = Sentinel.Length;
+        _suppressProxyChange = false;
     }
 
     private void OnGridResized(object? sender, (int Columns, int Rows) grid)

--- a/src/OpenIPC.Viewer.App/Views/MainView.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/MainView.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Platform;
 using OpenIPC.Viewer.App.ViewModels;
 
 namespace OpenIPC.Viewer.App.Views;
@@ -44,6 +45,7 @@ public partial class MainView : UserControl
     private bool _showBottomNav;
     private Thickness _contentPadding = WidePadding;
     private MainWindowViewModel? _vm;
+    private IInsetsManager? _insets;
 
     public bool ShowSidebar => _showSidebar;
     public bool ShowBottomNav => _showBottomNav;
@@ -59,6 +61,36 @@ public partial class MainView : UserControl
         _isWideLayout = Bounds.Width >= WideBreakpoint;
         UpdateChrome();
     }
+
+    // Mobile draws edge-to-edge under the system status bar, which put page
+    // titles beneath the clock and made the Settings back-link untappable.
+    // Inset the whole view by the platform safe area instead; null on desktop,
+    // and zeroed while fullscreen video hides the system bars.
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        _insets = TopLevel.GetTopLevel(this)?.InsetsManager;
+        if (_insets is not null)
+        {
+            _insets.SafeAreaChanged += OnSafeAreaChanged;
+            ApplySafeArea();
+        }
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        if (_insets is not null)
+        {
+            _insets.SafeAreaChanged -= OnSafeAreaChanged;
+            _insets = null;
+        }
+    }
+
+    private void OnSafeAreaChanged(object? sender, SafeAreaChangedArgs e) => ApplySafeArea();
+
+    private void ApplySafeArea() =>
+        Padding = _isFullscreen ? default : _insets?.SafeAreaPadding ?? default;
 
     protected override void OnSizeChanged(SizeChangedEventArgs e)
     {
@@ -135,5 +167,6 @@ public partial class MainView : UserControl
         SetAndRaise(ShowSidebarProperty, ref _showSidebar, showSidebar);
         SetAndRaise(ShowBottomNavProperty, ref _showBottomNav, showBottomNav);
         SetAndRaise(ContentPaddingProperty, ref _contentPadding, padding);
+        ApplySafeArea();
     }
 }

--- a/src/OpenIPC.Viewer.App/Views/MobileSplashView.axaml
+++ b/src/OpenIPC.Viewer.App/Views/MobileSplashView.axaml
@@ -1,0 +1,35 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:svc="using:OpenIPC.Viewer.App.Services"
+             xmlns:controls="using:OpenIPC.Viewer.App.Controls"
+             x:Class="OpenIPC.Viewer.App.Views.MobileSplashView"
+             Background="{StaticResource Bg1Brush}"
+             FontFamily="{StaticResource FontSans}">
+
+  <!-- Mobile startup overlay (single-view lifetime). Android/iOS run the DB
+       bootstrap in the platform host before Avalonia starts, so unlike the
+       desktop StartupWindow this is purely visual — App.axaml.cs keeps it on
+       top of MainView for a minimum beat, then fades it out (the Opacity
+       transition below) and removes it from the tree. -->
+
+  <UserControl.Transitions>
+    <Transitions>
+      <DoubleTransition Property="Opacity" Duration="0:0:0.35" />
+    </Transitions>
+  </UserControl.Transitions>
+
+  <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center" Spacing="20">
+    <controls:SplashAperture Width="96" Height="96" HorizontalAlignment="Center" />
+    <StackPanel Spacing="6">
+      <TextBlock Text="OpenIPC Viewer"
+                 FontSize="22" FontWeight="SemiBold"
+                 HorizontalAlignment="Center"
+                 Foreground="{StaticResource TextPrimaryBrush}" />
+      <TextBlock Text="{Binding [Startup.Title], Source={x:Static svc:Localizer.Instance}}"
+                 FontSize="12" Opacity="0.6"
+                 HorizontalAlignment="Center"
+                 Foreground="{StaticResource TextPrimaryBrush}" />
+    </StackPanel>
+  </StackPanel>
+
+</UserControl>

--- a/src/OpenIPC.Viewer.App/Views/MobileSplashView.axaml.cs
+++ b/src/OpenIPC.Viewer.App/Views/MobileSplashView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace OpenIPC.Viewer.App.Views;
+
+public sealed partial class MobileSplashView : UserControl
+{
+    public MobileSplashView() => InitializeComponent();
+}

--- a/src/OpenIPC.Viewer.App/Views/Pages/CameraLibraryPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/CameraLibraryPage.axaml
@@ -181,6 +181,8 @@
                           Foreground="{StaticResource TextPrimaryBrush}"
                           Command="{Binding $parent[ItemsControl].((vm:CameraLibraryPageViewModel)DataContext).OpenSshTerminalCommand}"
                           CommandParameter="{Binding}" />
+                  <!-- Risky tool (Settings → Advanced): hidden until the shared
+                       "risky device tools" toggle is on. -->
                   <Button Content="{Binding [Library.RowFiles], Source={x:Static svc:Localizer.Instance}}"
                           Padding="10,6"
                           Background="Transparent"
@@ -188,6 +190,7 @@
                           BorderThickness="1"
                           CornerRadius="6"
                           Foreground="{StaticResource TextPrimaryBrush}"
+                          IsVisible="{Binding $parent[ItemsControl].((vm:CameraLibraryPageViewModel)DataContext).IsFileManagerEnabled}"
                           Command="{Binding $parent[ItemsControl].((vm:CameraLibraryPageViewModel)DataContext).OpenFileManagerCommand}"
                           CommandParameter="{Binding}" />
                   <Button Content="{Binding [Library.RowDevice], Source={x:Static svc:Localizer.Instance}}"

--- a/src/OpenIPC.Viewer.App/Views/Pages/SettingsPage.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Pages/SettingsPage.axaml
@@ -231,6 +231,10 @@
               </ComboBox.ItemTemplate>
             </ComboBox>
           </Grid>
+
+          <CheckBox IsChecked="{Binding ShowSplash}"
+                    Content="{Binding [Settings.Appearance.ShowSplash], Source={x:Static svc:Localizer.Instance}}"
+                    Foreground="{StaticResource TextPrimaryBrush}" />
         </StackPanel>
 
         <!-- Video -->

--- a/src/OpenIPC.Viewer.App/Views/StartupWindow.axaml
+++ b/src/OpenIPC.Viewer.App/Views/StartupWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:OpenIPC.Viewer.App.ViewModels"
         xmlns:svc="using:OpenIPC.Viewer.App.Services"
+        xmlns:controls="using:OpenIPC.Viewer.App.Controls"
         x:Class="OpenIPC.Viewer.App.Views.StartupWindow"
         x:DataType="vm:StartupViewModel"
         Title="OpenIPC Viewer"
@@ -12,49 +13,6 @@
         WindowStartupLocation="CenterScreen"
         Background="{StaticResource Bg1Brush}">
 
-  <Window.Styles>
-    <!-- Occasional "aperture blink": squash the whole mark vertically for a few
-         frames on a long loop, reading as a blink rather than a flicker. -->
-    <Style Selector="Canvas.mark">
-      <Setter Property="RenderTransformOrigin" Value="0.5,0.5" />
-    </Style>
-    <Style Selector="Canvas.mark">
-      <Style.Animations>
-        <Animation Duration="0:0:3.8" IterationCount="INFINITE">
-          <KeyFrame Cue="0%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
-          <KeyFrame Cue="88%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
-          <KeyFrame Cue="93%"><Setter Property="ScaleTransform.ScaleY" Value="0.08" /></KeyFrame>
-          <KeyFrame Cue="98%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
-          <KeyFrame Cue="100%"><Setter Property="ScaleTransform.ScaleY" Value="1" /></KeyFrame>
-        </Animation>
-      </Style.Animations>
-    </Style>
-
-    <!-- The "pupil" looks left↔right, like a camera scanning the room. -->
-    <Style Selector="Ellipse.dot">
-      <Style.Animations>
-        <Animation Duration="0:0:4" IterationCount="INFINITE" Easing="SineEaseInOut">
-          <KeyFrame Cue="0%"><Setter Property="TranslateTransform.X" Value="0" /></KeyFrame>
-          <KeyFrame Cue="22%"><Setter Property="TranslateTransform.X" Value="-9" /></KeyFrame>
-          <KeyFrame Cue="50%"><Setter Property="TranslateTransform.X" Value="0" /></KeyFrame>
-          <KeyFrame Cue="72%"><Setter Property="TranslateTransform.X" Value="9" /></KeyFrame>
-          <KeyFrame Cue="100%"><Setter Property="TranslateTransform.X" Value="0" /></KeyFrame>
-        </Animation>
-      </Style.Animations>
-    </Style>
-
-    <!-- Accent glow ring brightens as the dot contracts (the "focus" snap). -->
-    <Style Selector="Ellipse.glow">
-      <Style.Animations>
-        <Animation Duration="0:0:1.8" IterationCount="INFINITE" Easing="SineEaseInOut">
-          <KeyFrame Cue="0%"><Setter Property="Opacity" Value="0.15" /></KeyFrame>
-          <KeyFrame Cue="50%"><Setter Property="Opacity" Value="0.55" /></KeyFrame>
-          <KeyFrame Cue="100%"><Setter Property="Opacity" Value="0.15" /></KeyFrame>
-        </Animation>
-      </Style.Animations>
-    </Style>
-  </Window.Styles>
-
   <Border Background="{StaticResource Bg1Brush}"
           BorderBrush="{StaticResource BorderMediumBrush}"
           BorderThickness="1">
@@ -63,37 +21,7 @@
       <StackPanel Grid.Row="0" Orientation="Horizontal"
                   VerticalAlignment="Center" Spacing="18">
 
-        <!-- Animated OpenIPC aperture mark -->
-        <Viewbox Width="62" Height="62" IsVisible="{Binding IsBusy}">
-          <Canvas Width="100" Height="100">
-            <Canvas Classes="mark" Width="100" Height="100">
-              <!-- Left chevron < -->
-              <Path Data="M33,29 L5,50 L33,71"
-                    Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
-                    StrokeLineCap="Flat" StrokeJoin="Round" />
-              <!-- Right chevron > -->
-              <Path Data="M67,29 L95,50 L67,71"
-                    Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
-                    StrokeLineCap="Flat" StrokeJoin="Round" />
-              <!-- Top cap arc ⌒ -->
-              <Path Data="M37,27 C43,12 57,12 63,27"
-                    Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
-                    StrokeLineCap="Round" />
-              <!-- Bottom cap arc ⌣ -->
-              <Path Data="M37,73 C43,88 57,88 63,73"
-                    Stroke="{StaticResource TextPrimaryBrush}" StrokeThickness="9"
-                    StrokeLineCap="Round" />
-              <!-- Accent focus glow behind the dot -->
-              <Ellipse Classes="glow" Canvas.Left="32" Canvas.Top="32"
-                       Width="36" Height="36"
-                       Stroke="{StaticResource AccentBrush}" StrokeThickness="6" />
-              <!-- Center dot (focus pulse) -->
-              <Ellipse Classes="dot" Canvas.Left="37" Canvas.Top="37"
-                       Width="26" Height="26"
-                       Fill="{StaticResource TextPrimaryBrush}" />
-            </Canvas>
-          </Canvas>
-        </Viewbox>
+        <controls:SplashAperture Width="62" Height="62" IsVisible="{Binding IsBusy}" />
 
         <StackPanel VerticalAlignment="Center" Spacing="6">
           <TextBlock Text="OpenIPC Viewer"

--- a/src/OpenIPC.Viewer.Infrastructure/Video/Decoders/VaapiDecoderFactory.cs
+++ b/src/OpenIPC.Viewer.Infrastructure/Video/Decoders/VaapiDecoderFactory.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using OpenIPC.Viewer.Core.Video;
 
@@ -22,11 +23,32 @@ public sealed class VaapiDecoderFactory : IHwDecoderFactory
         try
         {
             using var _ = File.OpenRead(RenderNode);
-            return HwProbeResult.Ok();
         }
         catch (System.Exception ex)
         {
             return HwProbeResult.Unavailable($"{RenderNode} not readable: {ex.Message}");
         }
+
+        // The bundled BtbN FFmpeg links libva via Implib.so lazy shims built
+        // against libva >= 2.21. If the system libva.so.2 is missing a symbol
+        // the shim resolves (vaMapBuffer2, added in 2.21) — or is missing
+        // entirely — the generated trampoline assert()s and abort()s the whole
+        // process as soon as VAAPI decode transfers a frame. That native abort
+        // cannot be caught from managed code, so verify up front and fall back
+        // to software decode instead.
+        if (!NativeLibrary.TryLoad("libva.so.2", out var libva))
+            return HwProbeResult.Unavailable("libva.so.2 not found");
+        try
+        {
+            if (!NativeLibrary.TryGetExport(libva, "vaMapBuffer2", out _))
+                return HwProbeResult.Unavailable(
+                    "system libva older than 2.21 (no vaMapBuffer2); bundled FFmpeg would abort");
+        }
+        finally
+        {
+            NativeLibrary.Free(libva);
+        }
+
+        return HwProbeResult.Ok();
     }
 }


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

- SSH terminal: invisible IME proxy + special-keys bar (Esc/Tab/Ctrl/arrows) so Android/iOS get a soft keyboard; desktop path unchanged
- one shared "risky device tools" toggle now also gates the library Files button; per-open risk confirm dropped (the opt-in is the consent)
- splash aperture extracted into a reusable control; single-view (mobile) shows it as a fading startup overlay; new "show splash" setting gates it on desktop and mobile
## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [x] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [x] Windows
- [ ] Linux
- [ ] macOS
- [x] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
