### PR TITLE
fix(editor): XM Sofia-hash template + wider dialog

### DIFF
--- a/src/OpenIPC.Viewer.App/ViewModels/Dialogs/CameraEditorViewModel.cs
+++ b/src/OpenIPC.Viewer.App/ViewModels/Dialogs/CameraEditorViewModel.cs
@@ -179,6 +179,9 @@ public sealed partial class CameraEditorViewModel : ViewModelBase
             "xm" => (
                 $"rtsp://{host}:554/user={user}&password={Password}&channel=1&stream=0.sdp?real_stream",
                 $"rtsp://{host}:554/user={user}&password={Password}&channel=1&stream=1.sdp?real_stream"),
+            "xm-sofia" => (
+                $"rtsp://{host}:554/user={user}&password={SofiaHash(Password)}&channel=1&stream=0.sdp?real_stream",
+                $"rtsp://{host}:554/user={user}&password={SofiaHash(Password)}&channel=1&stream=1.sdp?real_stream"),
             "hikvision" => (
                 $"rtsp://{host}:554/Streaming/Channels/101",
                 $"rtsp://{host}:554/Streaming/Channels/102"),
@@ -196,6 +199,23 @@ public sealed partial class CameraEditorViewModel : ViewModelBase
                 $"rtsp://{host}:554/media/video2"),
             _ => (RtspMainText, RtspSubText),
         };
+    }
+
+    // XM/Xiongmai "Sofia" password digest (NETSurveillance/DVRIP): pairs of MD5
+    // bytes summed mod 62, mapped to [0-9A-Za-z], 8 chars. Newer XM firmwares
+    // reject the plaintext password in the RTSP URL and want this instead
+    // (empty password hashes to the well-known "tlJwpbo6"). MD5 here is a
+    // protocol requirement, not our choice of cryptography.
+    private static string SofiaHash(string password)
+    {
+        var md5 = System.Security.Cryptography.MD5.HashData(System.Text.Encoding.UTF8.GetBytes(password));
+        var chars = new char[8];
+        for (var i = 0; i < 8; i++)
+        {
+            var n = (md5[2 * i] + md5[2 * i + 1]) % 62;
+            chars[i] = (char)(n < 10 ? '0' + n : n < 36 ? 'A' + n - 10 : 'a' + n - 36);
+        }
+        return new string(chars);
     }
 
     [RelayCommand(CanExecute = nameof(CanTestConnection))]

--- a/src/OpenIPC.Viewer.App/Views/Dialogs/CameraEditorContent.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/CameraEditorContent.axaml
@@ -63,6 +63,7 @@
                 <MenuFlyout Placement="BottomEdgeAlignedRight">
                   <MenuItem Header="OpenIPC (Majestic)" Command="{Binding ApplyRtspTemplateCommand}" CommandParameter="openipc" />
                   <MenuItem Header="XM / Xiongmai (NETSurveillance)" Command="{Binding ApplyRtspTemplateCommand}" CommandParameter="xm" />
+                  <MenuItem Header="XM / Xiongmai (Sofia hash)" Command="{Binding ApplyRtspTemplateCommand}" CommandParameter="xm-sofia" />
                   <MenuItem Header="Hikvision" Command="{Binding ApplyRtspTemplateCommand}" CommandParameter="hikvision" />
                   <MenuItem Header="Dahua / Amcrest" Command="{Binding ApplyRtspTemplateCommand}" CommandParameter="dahua" />
                   <MenuItem Header="Reolink" Command="{Binding ApplyRtspTemplateCommand}" CommandParameter="reolink" />

--- a/src/OpenIPC.Viewer.App/Views/Dialogs/CameraEditorWindow.axaml
+++ b/src/OpenIPC.Viewer.App/Views/Dialogs/CameraEditorWindow.axaml
@@ -5,7 +5,7 @@
         x:Class="OpenIPC.Viewer.App.Views.Dialogs.CameraEditorWindow"
         x:DataType="vm:CameraEditorViewModel"
         Title="{Binding Title}"
-        Width="520" Height="640"
+        Width="560" Height="680"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
         Background="{StaticResource Bg1Brush}">


### PR DESCRIPTION
- new "XM (Sofia hash)" entry: 8-char NETSurveillance MD5 digest in password= (newer XM firmwares reject plaintext in the RTSP URL)
- camera editor window 520x640 -> 560x680 (content clipped by the scrollbar)

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

<!-- What does this PR do and why? -->

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [ ] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [x] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [ ] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
