### PR TITLE
Fix/ci ffmpeg pin ssh bump

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,8 +57,13 @@
     <PackageVersion Include="Onvif.Core" Version="3.0.0" />
 
     <!-- Phase 13: SSH device suite. Pure-managed SSH/SCP (no native bins) so it
-         links on every .NET target including Android/iOS. -->
-    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+         links on every .NET target including Android/iOS.
+         2026.0.0 is the first release without GHSA-q939-rpr3-3284: ScpClient's
+         recursive download trusted server-supplied filenames, so a hostile (or
+         compromised) camera could write outside the download directory. With
+         NuGetAudit + TreatWarningsAsErrors the advisory also fails restore, so
+         staying on 2025.1.0 is not an option anyway. -->
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <!-- Avalonia.Skia 12.0.3 pulls SkiaSharp 3.119.4-preview.1.1 transitively; match it explicitly. -->
     <PackageVersion Include="SkiaSharp" Version="3.119.4-preview.1.1" />
     <!-- Linux native libSkiaSharp for the Avalonia-less test process. The

--- a/src/OpenIPC.Viewer.Infrastructure/Ssh/SshNetSession.cs
+++ b/src/OpenIPC.Viewer.Infrastructure/Ssh/SshNetSession.cs
@@ -61,7 +61,12 @@ internal sealed class SshNetSession : ISshSession
             _presentedFingerprint = null;
 
             _ssh = new SshClient(BuildConnectionInfo(endpoint));
-            _scp = new ScpClient(BuildConnectionInfo(endpoint));
+            // ShellQuote, not the default: SCP is a remote shell command, so an
+            // unescaped path is command injection by a hostile camera. SSH.NET
+            // 2026.0.0 deprecates the transformation-less constructor for that
+            // reason. The cameras run busybox/dropbear, where POSIX shell
+            // quoting is the right escaping rule.
+            _scp = new ScpClient(BuildConnectionInfo(endpoint), RemotePathTransformation.ShellQuote);
             _ssh.HostKeyReceived += OnHostKeyReceived;
             _scp.HostKeyReceived += OnHostKeyReceived;
 

--- a/tools/fetch-ffmpeg-linux.sh
+++ b/tools/fetch-ffmpeg-linux.sh
@@ -15,13 +15,23 @@
 # contained, exactly like fetch-ffmpeg.ps1 does for win-x64.
 #
 # Source:  BtbN/FFmpeg-Builds GitHub releases (https://github.com/BtbN/FFmpeg-Builds).
-# Pin:     n7.1 (matches FFmpeg.AutoGen 7.1.x bindings).
+# Pin:     n7.1 (matches FFmpeg.AutoGen 7.1.x bindings), from a dated release
+#          rather than the rolling `latest` tag. `latest` is rebuilt daily and
+#          only keeps the branches BtbN currently builds: n7.1 was dropped from
+#          it in August 2026 (only master / n8.1 / n9.0 remain), which 404'd this
+#          script and took CI down with it. A dated tag keeps its assets, and the
+#          SHA-256 below makes a silently swapped or truncated archive fail here
+#          instead of at runtime.
 # Flavor:  lgpl-shared (no GPL components; redistributable alongside the app as
 #          long as the .so remain shared + replaceable — see README "Licensing").
 set -euo pipefail
 
-FFMPEG_VERSION="${FFMPEG_VERSION:-n7.1}"
-ASSET_NAME="${ASSET_NAME:-ffmpeg-${FFMPEG_VERSION}-latest-linux64-lgpl-shared-7.1.tar.xz}"
+# Overridable together: a different release/asset needs its own checksum, and
+# an empty EXPECTED_SHA256 skips the check (with a warning) rather than failing
+# every override.
+FFMPEG_RELEASE="${FFMPEG_RELEASE:-autobuild-2026-08-16-13-00}"
+ASSET_NAME="${ASSET_NAME:-ffmpeg-n7.1.5-16-g9a4bb2c579-linux64-lgpl-shared-7.1.tar.xz}"
+EXPECTED_SHA256="${EXPECTED_SHA256-05e4cf57a4f8bb63bda8a1a306dbf370c03e305088e7153c02e7761b2c181ec0}"
 FORCE="${FORCE:-0}"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -30,15 +40,49 @@ cache_dir="$repo_root/.cache/ffmpeg"
 archive_path="$cache_dir/$ASSET_NAME"
 extract_dir="$cache_dir/${ASSET_NAME%.tar.xz}"
 
-download_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$ASSET_NAME"
+download_url="https://github.com/BtbN/FFmpeg-Builds/releases/download/$FFMPEG_RELEASE/$ASSET_NAME"
 
 mkdir -p "$native_dir" "$cache_dir"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+download() {
+  echo "[fetch-ffmpeg-linux] downloading $download_url"
+  curl -fL --retry 3 -o "$archive_path" "$download_url"
+}
 
 if [[ -f "$archive_path" && "$FORCE" != "1" ]]; then
   echo "[fetch-ffmpeg-linux] using cached $archive_path"
 else
-  echo "[fetch-ffmpeg-linux] downloading $download_url"
-  curl -fL --retry 3 -o "$archive_path" "$download_url"
+  download
+fi
+
+if [[ -z "$EXPECTED_SHA256" ]]; then
+  echo "[fetch-ffmpeg-linux] EXPECTED_SHA256 empty — skipping integrity check" >&2
+else
+  actual="$(sha256_of "$archive_path")"
+  if [[ "$actual" != "$EXPECTED_SHA256" ]]; then
+    # A stale or half-written cache is the likely cause, so spend one retry on
+    # it before giving up.
+    echo "[fetch-ffmpeg-linux] checksum mismatch on $archive_path — re-downloading" >&2
+    rm -f "$archive_path"
+    download
+    actual="$(sha256_of "$archive_path")"
+  fi
+  if [[ "$actual" != "$EXPECTED_SHA256" ]]; then
+    echo "[fetch-ffmpeg-linux] SHA-256 mismatch, refusing to unpack:" >&2
+    echo "  expected $EXPECTED_SHA256" >&2
+    echo "  got      $actual" >&2
+    rm -f "$archive_path"
+    exit 1
+  fi
+  echo "[fetch-ffmpeg-linux] sha256 ok"
 fi
 
 rm -rf "$extract_dir"

--- a/tools/fetch-ffmpeg.ps1
+++ b/tools/fetch-ffmpeg.ps1
@@ -6,14 +6,21 @@
 
 .NOTES
   Source: BtbN/FFmpeg-Builds GitHub releases (https://github.com/BtbN/FFmpeg-Builds).
-  Version pin: n7.1 (matches FFmpeg.AutoGen 7.1.x bindings).
+  Version pin: n7.1 (matches FFmpeg.AutoGen 7.1.x bindings), taken from a dated
+  release rather than the rolling `latest` tag - `latest` only keeps the branches
+  BtbN currently builds, and n7.1 was dropped from it in August 2026 (master /
+  n8.1 / n9.0 remain), which 404'd this script. The SHA-256 below turns a swapped
+  or truncated archive into a failure here instead of at runtime.
   Build flavor: lgpl-shared (no GPL components; safe to redistribute alongside
   a closed-source app provided DLLs remain replaceable).
 #>
 [CmdletBinding()]
 param(
-    [string]$FfmpegVersion = "n7.1",
-    [string]$AssetName     = "ffmpeg-n7.1-latest-win64-lgpl-shared-7.1.zip",
+    [string]$FfmpegRelease  = "autobuild-2026-08-16-13-00",
+    [string]$AssetName      = "ffmpeg-n7.1.5-16-g9a4bb2c579-win64-lgpl-shared-7.1.zip",
+    # A different release/asset needs its own hash; pass an empty string to skip
+    # the check rather than have every override fail.
+    [string]$ExpectedSha256 = "a950596cea0bf9766f169dae6f1e6eb623aa1ccfd2822cd20cd2874b120d4086",
     [switch]$Force
 )
 
@@ -25,7 +32,7 @@ $cacheDir   = Join-Path $repoRoot ".cache/ffmpeg"
 $zipPath    = Join-Path $cacheDir $AssetName
 $extractDir = Join-Path $cacheDir ($AssetName -replace "\.zip$","")
 
-$downloadUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$AssetName"
+$downloadUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$FfmpegRelease/$AssetName"
 
 # Required runtime DLLs only — header/license files don't ship.
 $requiredDlls = @(
@@ -41,11 +48,35 @@ $requiredDlls = @(
 New-Item -ItemType Directory -Force -Path $nativeDir | Out-Null
 New-Item -ItemType Directory -Force -Path $cacheDir  | Out-Null
 
+function Get-FfmpegArchive {
+    Write-Host "[fetch-ffmpeg] downloading $downloadUrl"
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
+}
+
 if ((Test-Path $zipPath) -and -not $Force) {
     Write-Host "[fetch-ffmpeg] using cached $zipPath"
 } else {
-    Write-Host "[fetch-ffmpeg] downloading $downloadUrl"
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath -UseBasicParsing
+    Get-FfmpegArchive
+}
+
+if ([string]::IsNullOrWhiteSpace($ExpectedSha256)) {
+    Write-Warning "[fetch-ffmpeg] ExpectedSha256 empty - skipping integrity check"
+} else {
+    $expected = $ExpectedSha256.Trim().ToUpperInvariant()
+    $actual = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash
+    if ($actual -ne $expected) {
+        # A stale or half-written cache is the likely cause, so spend one retry
+        # on it before giving up.
+        Write-Warning "[fetch-ffmpeg] checksum mismatch on $zipPath - re-downloading"
+        Remove-Item -LiteralPath $zipPath -Force
+        Get-FfmpegArchive
+        $actual = (Get-FileHash -LiteralPath $zipPath -Algorithm SHA256).Hash
+    }
+    if ($actual -ne $expected) {
+        Remove-Item -LiteralPath $zipPath -Force
+        throw "[fetch-ffmpeg] SHA-256 mismatch, refusing to unpack: expected $expected, got $actual"
+    }
+    Write-Host "[fetch-ffmpeg] sha256 ok"
 }
 
 if (Test-Path $extractDir) {


### PR DESCRIPTION
<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

<!-- What does this PR do and why? -->

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [x] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [ ] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [x] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
