### PR TITLE
docs: refresh roadmap, guides and README for 0.3.8

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,11 +6,11 @@ review cycles short.
 
 ## Branches and PRs
 
-- Work on a feature branch off `main`. Branch names: `phase-NN-short-slug`
-  for phase-bound work, `fix-short-slug` or `feat-short-slug` otherwise.
+- Work on a feature branch off `main`. Branch names: `feat/short-slug` or
+  `fix/short-slug`.
 - Open the PR against `main`. Squash-merge is the default; the squash
   commit message should explain the *why*, not restate the diff.
-- Keep PRs small. One phase sub-step per PR (e.g. "Phase 9c: in-process
+- Keep PRs small — one self-contained step per PR (e.g. "in-process
   recording + foreground service on Android" is one PR; the touch-UX
   follow-up is another).
 
@@ -20,13 +20,17 @@ review cycles short.
   0 errors**. `TreatWarningsAsErrors=true` is enforced.
 - `dotnet test OpenIPC.Viewer.slnx --no-build` must pass; the MediaMTX
   integration test auto-skips when the container isn't running.
-- CI runs the matrix on every code push (docs-only pushes are skipped);
-  don't ignore red status.
+- The build also compiles the React web console (`npm ci` + `npm run build`
+  from `src/OpenIPC.Viewer.Web.Client`). Install Node if you touch the web UI;
+  without it the target is skipped and the server builds API-only.
+- CI runs the Windows / Linux / macOS matrix plus the Android and iOS heads
+  on every code push (docs-only pushes are skipped); don't ignore red status.
 
 ## Code style
 
-- Code, identifiers, log messages, commit messages: English.
-- Phase planning docs (`phase-NN-*.md`): Russian.
+- Code, identifiers, log messages, commit messages, docs: English.
+  (`docs/web-server.ru.md` is a translation of an English original; UI strings
+  live in `Localizer.cs` in both languages.)
 - One blank line between members; sealed `partial` classes when XAML
   code-behind or `CommunityToolkit.Mvvm` source-gen is involved.
 - Comments only where the *why* is non-obvious; well-named identifiers
@@ -40,9 +44,9 @@ review cycles short.
   `IHwDecoderFactory`) is wired per-platform in each head's
   `Composition.cs`. Shared registrations belong in
   `OpenIPC.Viewer.Composition.SharedComposition`.
-- Don't blur work from later phases into earlier ones — each
-  `phase-NN-*.md` has a **Не входит** section listing what's
-  deliberately out of scope.
+- Keep a change inside the scope it claims. Where the roadmap
+  ([docs/ROADMAP.md](../docs/ROADMAP.md)) puts something in a later phase,
+  leave it there rather than folding it in opportunistically.
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ dotnet run --project src/OpenIPC.Viewer.Desktop
 ```
 
 Build runs with `TreatWarningsAsErrors=true`; any warning fails the build.
+The web console's React SPA is built by the same `dotnet build` (`npm ci` +
+`npm run build`, then embedded into `OpenIPC.Viewer.Web.dll`), so Node is a
+prerequisite if you want the browser UI (CI builds it with Node 22). Without
+Node the build still succeeds and the server runs API-only; pass
+`-p:BuildWebClient=false` to skip it deliberately.
+
 Run the FFmpeg fetch script for your OS once — it downloads the bundled
 shared-build (`n7.1` ABI) from `BtbN/FFmpeg-Builds` into `runtimes/<rid>/native/`:
 `tools/fetch-ffmpeg.ps1` (Windows → `win-x64`) or `tools/fetch-ffmpeg-linux.sh`
@@ -180,12 +186,18 @@ src/
   OpenIPC.Viewer.Devices/         net9.0         — ONVIF, Majestic HTTP, SSH, discovery sources
   OpenIPC.Viewer.App/             net9.0         — Avalonia views and viewmodels (cross-platform)
   OpenIPC.Viewer.Composition/     net9.0         — shared DI registrations (used by every head)
+  OpenIPC.Viewer.Web/             net9.0         — Kestrel host + REST API for the self-hosted console
+  OpenIPC.Viewer.Web.Client/      —              — React + Vite SPA, built and embedded into the Web dll
   OpenIPC.Viewer.Desktop/         net9.0         — Win/Lin/Mac host, classic-window lifetime
   OpenIPC.Viewer.Android/         net10.0-android — Android host (min API 31), foreground-service recording
   OpenIPC.Viewer.iOS/             net10.0-ios     — iOS host (min 16), foreground-only recording
 tests/
-  OpenIPC.Viewer.Core.Tests/      xUnit
-  OpenIPC.Viewer.Video.Tests/     xUnit + MediaMTX integration
+  OpenIPC.Viewer.Core.Tests/           xUnit
+  OpenIPC.Viewer.Devices.Tests/        xUnit — ONVIF, Majestic, discovery
+  OpenIPC.Viewer.Infrastructure.Tests/ xUnit — SQLite, migrations, secrets
+  OpenIPC.Viewer.Analytics.Tests/      xUnit — detection pre/post-processing
+  OpenIPC.Viewer.Web.Tests/            xUnit — API, auth, permissions
+  OpenIPC.Viewer.Video.Tests/          xUnit + MediaMTX integration
 ```
 
 `App` references `Core` only. Infrastructure, Video, Devices and the platform

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,8 +4,11 @@ High-level status of OpenIPC Viewer. The project is built in phases — each
 phase ends with a demonstrable, releasable increment. This page tracks where
 things stand; it is a summary, not a commitment to dates.
 
-> **Current status:** feature-complete for the first desktop beta. Work in
-> progress is **Phase 11** — release polish (packaging, auto-update, signing).
+> **Current status:** public beta, shipping regularly — latest release
+> **`v0.3.8`** for Windows / Linux / macOS / Android. Every feature phase
+> through 21 is done; what remains from the plan is **distribution**
+> (native installers, in-app auto-update, code signing, F-Droid) plus
+> on-device validation across the non-Windows heads.
 
 ## Phases
 
@@ -22,34 +25,38 @@ things stand; it is a summary, not a commitment to dates.
 | 8 | Linux + macOS heads | VAAPI / VideoToolbox, keyring credentials | ✅ Done |
 | 9 | Android head | MediaCodec decode, in-process recording | ✅ Done |
 | 10 | iOS head | VideoToolbox, foreground-only recording | ✅ Done |
-| 11 | Onboarding + polish + release | Packaging, auto-update, signing, store delivery | 🚧 In progress |
+| 11 | Onboarding + polish + release | Packaging, auto-update, signing, store delivery | 🚧 Distribution only |
 
 ## Milestones
 
-- **`v0.1.0-beta` (desktop)** — Phases 0–8 plus release polish.
+- **`v0.1.x-beta` (desktop)** — Phases 0–8 plus release polish.
   Windows / Linux / macOS standalone builds.
-- **`v0.2.0-beta` (mobile)** — Phases 9–10. Android + iOS heads.
+- **`v0.2.x-beta` (mobile)** — Phases 9–10. Android + iOS heads.
+- **`v0.3.x` (current)** — post-MVP phases 12–17 and 19–21: AI detection,
+  two-way audio, archive pro, tabbed layouts, the self-hosted web console,
+  aggregated discovery, and a long tail of platform fixes.
 
 ## Phase 11 — remaining
 
-Polish items still open before tagging the betas:
+Everything left before the betas stop being betas is packaging and signing:
 
-- [ ] QR-code camera add (scan to provision)
 - [ ] In-app auto-update (Velopack) + native installers
 - [ ] Code signing (Windows / macOS) and Play / TestFlight signing
 - [ ] F-Droid packaging
+- [x] QR-code camera add (decode a saved QR image → pre-filled editor;
+      in-camera scanning on mobile is still open)
 - [x] Snapshot share sheet
-- [ ] Localization polish (English / Russian)
+- [x] Localization (English / Russian, switched at runtime)
 
 > **Validation caveat.** Linux / macOS / Android / iOS code paths build and
 > link in CI but are not yet end-to-end tested on real devices for every
 > commit. Feedback is welcome — open an issue with OS version and steps.
 
-## Post-MVP — planned enhancements (Phases 12+)
+## Post-MVP — enhancement phases (12+)
 
 Enhancement phases distilled from a full review of competing-client release
-notes, all designed cross-platform (Win / Lin / Mac / Android / iOS). Rationale
-and scope live in the planning docs (`dashboard-ideas-roadmap-ru.md`).
+notes, all designed cross-platform (Win / Lin / Mac / Android / iOS), plus a
+server track that grew out of them.
 
 | # | Phase | Scope | Status |
 |---|---|---|:---:|
@@ -58,11 +65,38 @@ and scope live in the planning docs (`dashboard-ideas-roadmap-ru.md`).
 | 14 | Snapshots & viewer | Always-HD snapshot, snapshot browser, built-in viewer + basic editor | ✅ Done |
 | 15 | Local AI analytics | ONNX object detection per camera, auto-record, control center, CPU fallback | ✅ Done |
 | 16 | Archive pro | Fragmented MP4, activity calendar, timeline zoom, clip export | ✅ Done |
-| 17 | Community & app-level | Tabbed layouts, config export/import, notifications, white-label, issue reporter, RBAC | 📋 Planned |
+| 17 | Two-way audio | Listen (AAC / G.711) in grid + single view, push-to-talk over the ONVIF backchannel | ✅ Done |
 | 18 | Streq remote access | Cloud multistreaming across devices: LAN/overlay/relay routing, enrollment, WebRTC/HLS, cross-device sync | 📋 Planned |
+| 19 | Community & app-level | Tabbed layouts, config export/import, notifications, issue reporter | ✅ Done |
+| 20 | Web server (LAN self-host) | Kestrel host behind `--server-only`, accounts + permissions, camera subsets | ✅ Done |
+| 21 | Web UI as a React SPA | Live grid, PTZ, discovery, archive, snapshots, audio, Majestic panel in the browser | ✅ Done |
+
+Deferred out of Phase 19: white-label `branding.json` and granular RBAC on the
+desktop app (the web console has its own per-user permissions and camera
+subsets instead).
+
+### Shipped alongside the phases
+
+Work that came from real-camera use rather than the phase plan, all released
+in the 0.3.x line:
+
+- **Discovery v2** — ONVIF WS-Discovery + mDNS + opt-in subnet sweep merged
+  into one result list, with OpenIPC web fingerprinting, multi-add from a
+  single scan, and manual IP ranges.
+- **Health & status** — one status verdict per camera (online / attention /
+  offline) shared by grid, library and a Health Center overview.
+- **Majestic Control Center** — schema-driven `config.json` editor with live
+  ISP tuning and read-only metrics, on top of the curated panel.
+- **Device tools** — reboot / clock / log snapshots over SSH, plus
+  user-defined SSH camera actions surfaced as grid buttons.
+- **Desktop niceties** — tray icon with quick actions, close-to-tray,
+  fullscreen kiosk mode, grid pagination, low-cost "stills" mode, optional
+  single-instance mode.
+- **Mobile UX** — safe-area insets, soft-keyboard handling for the SSH
+  terminal, mobile splash, and a gate on risky device tools.
 
 > **Phase 18** is the viewer side of our own **Streq** cloud (WireGuard/n3n
 > overlay + go2rtc/MediaMTX media relay) for remote multistreaming across
 > devices. The cloud/agent side lives in a separate `streq` repo with its own
-> phasing; Phase 18 starts once the Streq coordinator (Stage I) is up, so it can
-> run as a parallel track to Phases 12–17.
+> phasing; the viewer work starts once the Streq coordinator is up, so it runs
+> as a parallel track.

--- a/docs/first-camera.md
+++ b/docs/first-camera.md
@@ -2,15 +2,18 @@
 
 Three paths, listed cheapest-to-most-manual.
 
-## 1. WS-Discovery (LAN scan)
+## 1. Network discovery (LAN scan)
 
-Library → `🔍 Discover`. The app sends a WS-Discovery probe to the
-multicast group `239.255.255.250:3702`. Cameras with ONVIF responders
-answer within ~5 s; the dialog lists them with their advertised model and
-RTSP URI.
+Library → `Discover`. A scan runs two passive sources at once — ONVIF
+WS-Discovery (multicast `239.255.255.250:3702`) and mDNS — and merges the
+answers into one list, deduplicated per device, each entry tagged with what
+found it and how confident that is. Cameras with an ONVIF responder show up
+within ~5 s, with their advertised model and RTSP URI; OpenIPC devices
+without ONVIF are recognised by their web fingerprint.
 
 Pick a camera → enter credentials → the editor pre-fills name / host /
-RTSP / ONVIF profile. Save.
+RTSP / ONVIF profile. Save. The dialog stays open with the scan results, so
+several cameras can be added from one scan.
 
 ### Deep scan and where it sweeps
 
@@ -71,12 +74,25 @@ Library → `+ Add camera`. Fill in:
 
 ## 3. QR code
 
-*Comes in 11c.* Future: scan a QR with `rtsp://user:pass@host:port/path`
-or a JSON payload, app adds the camera in one tap.
+Library → `Scan QR` (also offered in the first-run welcome dialog). Pick a
+saved QR **image** — a screenshot, a photo, or the sticker sheet a camera
+shipped with — and the app decodes it and opens the camera editor pre-filled,
+so you review the fields before saving. Three payload shapes are understood:
+
+| Payload | Example |
+|---|---|
+| RTSP URL | `rtsp://admin:pass@192.168.1.50:554/0` |
+| JSON object | `{"name":"Gate","host":"192.168.1.50","rtsp":"rtsp://192.168.1.50/0","onvif":8000,"user":"admin","password":"…"}` |
+| App URI | `openipc-viewer://camera?host=192.168.1.50&rtsp=rtsp://192.168.1.50/0&user=admin` |
+
+Credentials found in the payload land in the editor's username / password
+fields and are stored in the keystore — they are never kept inside the saved
+RTSP URL. Scanning through the phone's camera (rather than picking an image)
+is not implemented yet.
 
 ## Common issues
 
-- **"Failed to connect" / `stimeout` errors** — wrong RTSP path. Camera
+- **"Failed to connect" / connection timeouts** — wrong RTSP path. Camera
   vendors love to pick different defaults (`/cam/realmonitor`, `/stream1`,
   `/h264`). Check the vendor docs.
 - **Auth loops** — the URI takes plain user/password but credentials live

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,14 +18,19 @@ Per-platform AppData root paths are in the README's **User data** section.
 
 ## First-run flow
 
-On first launch the library is empty and a welcome dialog appears with three
-choices:
+On first launch the library is empty and a welcome dialog appears — it also
+carries a language picker (English / Russian, switchable later in Settings) —
+with four choices:
 
-1. **Scan local network** — runs WS-Discovery against your subnet (Phase 4).
-   Most cameras with a working ONVIF responder are picked up within ~5 s.
-2. **Add manually** — host + RTSP path form. Use this if discovery misses the
+1. **Scan local network** — aggregated discovery: ONVIF WS-Discovery and mDNS
+   run together, with an optional *Deep scan* subnet sweep for cameras that
+   announce nothing. Most cameras with a working ONVIF responder are picked up
+   within ~5 s. See [Adding your first camera](first-camera.md).
+2. **Scan QR code** — pick a saved QR image (screenshot, photo, sticker) and
+   the camera editor opens pre-filled from it.
+3. **Add manually** — host + RTSP path form. Use this if discovery misses the
    camera or if it's on a different VLAN.
-3. **Skip** — opens an empty library; add cameras later from `+ Add camera`.
+4. **Skip** — opens an empty library; add cameras later from `+ Add camera`.
 
 The "show this once" flag is persisted; dismissing it once means the dialog
 doesn't reappear even if you later delete every camera.
@@ -40,3 +45,18 @@ doesn't reappear even if you later delete every camera.
 - **Settings → Advanced → Verbose logging** — flips Serilog's minimum level
   to Debug live, no restart needed. Useful when something doesn't connect
   and you want to see why before pinging an issue.
+
+## Moving to another machine
+
+*Settings → Backup → Export config* writes cameras and layouts to a single
+JSON; *Import* reads it back on the other machine, showing a preview of how many
+cameras and layouts will be added or updated before it commits. Passwords stay
+out of the file unless you tick *include credentials* and set a passphrase in
+the config-sync section — then they travel encrypted with it.
+
+## Running it as a server
+
+The same binary can serve a browser UI to the rest of your network instead of
+opening a window (`--server-only`). Flags, accounts and reverse-proxy examples
+are in the self-hosting guide ([English](web-server.md) ·
+[Русский](web-server.ru.md)).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,6 +73,25 @@ always-on, run a relay (MediaMTX / Frigate) on a server.
 `UIFileSharingEnabled = YES`; if files still don't appear, force-quit
 and reopen the app once to nudge `LSSupportsOpeningDocumentsInPlace`.
 
+## Web console (`--server-only`)
+
+**Page loads but says the UI isn't there / only the API answers.** The React SPA
+is compiled into the binary at build time by an `npm` step. A build made on a
+machine without Node (or with `-p:BuildWebClient=false`) ships API-only. Install
+Node and rebuild, or use a release archive.
+
+**Can't reach it from another device.** Without `--lan` the server binds to
+`127.0.0.1` on purpose. Add `--lan` (and mind that there is no TLS at this
+layer — put it behind a reverse proxy for anything wider than a trusted LAN).
+
+**Don't know the admin password.** If `OPENIPC_WEB_ADMIN_PASSWORD` isn't set, a
+random one is generated and printed to the log on every start — grab it from
+`logs/`, or set the variable and restart.
+
+**Deep scan finds nothing from the server.** A server-side sweep is restricted
+to private ranges (`10/8`, `172.16/12`, `192.168/16`) and refuses its own
+loopback. Anything else has to be reached from the desktop app instead.
+
 ## Cross-platform
 
 **App opens with no cameras after upgrade.** Database lives in the


### PR DESCRIPTION
- roadmap: phase statuses through 21, 0.3.x milestones, distribution-only Phase 11
- first-camera/getting-started: real QR flow, aggregated discovery, welcome dialog
- README: Web + Web.Client projects, full test list, Node prerequisite
- troubleshooting: web console section; CONTRIBUTING: current branch/CI/docs rules

<!-- Keep it short. Commit messages and this template are in English. -->

## Summary

<!-- What does this PR do and why? -->

## Related

<!-- Closes #123, or the phase this belongs to (e.g. "Phase 6 — Recording"). -->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup
- [x] Docs / CI
- [ ] Other:

## Checklist

- [x] Builds with **0 warnings** (`TreatWarningsAsErrors=true`).
- [x] Tests pass (`dotnet test`); new Core logic has unit tests.
- [x] No layering violation — `App` references `Core` only (Infrastructure / Video / Devices wired via DI in a head).
- [x] Scope stays within one phase (didn't pull work from a later phase's "Не входит").
- [x] README / docs updated if public commands, options, or setup changed.

## Platforms tested

<!-- Which heads did you actually run? e.g. Windows desktop; CI-only for the rest. -->

- [ ] Windows
- [ ] Linux
- [ ] macOS
- [ ] Android
- [ ] iOS
- [x] CI build only

## Screenshots / notes

<!-- For UI changes, before/after screenshots help. -->
